### PR TITLE
Makefile fix typo and added clean functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
 # ══════════════════════════════════════════════════════
+#                       COLOURS
+# ══════════════════════════════════════════════════════
+RES		= "\033[0m"
+RED		= "\033[91m"
+GREEN	= "\033[92m"
+YELLOW	= "\033[93m"
+ORANGE	= "\033[38;5;208m"
+CYAN	= "\033[96m"
+GOLD	= "\033[38;5;220m"
+
+# ══════════════════════════════════════════════════════
 #                      VARIABLES
 # ══════════════════════════════════════════════════════
 
@@ -52,16 +63,41 @@ logs-back: ## Display logs for the backend container
 # ══════════════════════════════════════════════════════
 
 clean: ## Remove dangling images, stopped containers, unused networks + build cache
-# ── Removes stopped containers ───────
-	docker container prune -f
-# ── Removes dangling images ──────────
-	docker image prune -f
-# ── Removes unused networks ──────────
-	docker network prune -f
-# ── clears build cache ───────────────
-	docker buildx prune -f
+# ── Remove stopped containers ───────
+	@echo $(CYAN)"<Removing Stopped Containers>"$(RES)
+	@docker container prune -f
+# ── Remove dangling images ──────────
+	@echo $(CYAN)"<Removing Dangling Images>"$(RES)
+	@docker image prune -f
+# ── Remove unused networks ──────────
+	@docker network prune -f
+# ── Clear build cache ───────────────
+	@echo $(CYAN)"<Removing Build Cache>"$(RES)
+	@docker buildx prune -f
 	@echo ""
 	@docker system df
 
+
+nuke: ## ⚠️  Full wipe — stops stack, removes volumes + images.
+	@echo $(ORANGE)"⚠️  This will destroy all containers, images, and volumes for this stack."
+	@echo "   Postgres data will be wiped."$(RES)
+	@printf "   Continue? [y/N] " && read ans && [ "$$ans" = "y" ] || (echo $(RED)"   Aborted"$(RES) && exit 1)
+ 
+	@echo ""
+	@echo $(CYAN)"<Stopping stack and removing containers + volumes>"$(RES)
+	@docker compose -f $(COMPOSE_FILE) down --volumes --remove-orphans
+ 
+	@echo $(CYAN)"<Removing images built by this stack>"$(RES)
+	@docker compose -f $(COMPOSE_FILE) down --rmi local 2>/dev/null || true
+	@docker image prune -f
+ 
+	@echo $(CYAN)"<Clearing all build cache>"$(RES)
+	@docker buildx prune -f
+ 
+	@echo ""
+	@echo $(GREEN)"Task completed. Everything is gone."$(RES)
+	@echo "   Run \`make up\` to rebuild from scratch."
+	@echo ""
+	@docker system df
 
 .PHONY: up build down no-cache ps ls logs logs-proxy logs-front logs-back clean nuke


### PR DESCRIPTION
# What was done
- Backend logs now properly shows backend logs
- Added options for cleaning/pruning containers
- Added ansi colour codes to Makefile for coloured terminal output

## make clean — Soft clean
`make clean` is safe to run while the stack is up
###  What it removes:
 - Dangling images (untagged, not attached to any container)
 - Stopped / exited containers (not part of the current stack)
 - Unused Docker networks
 - Unused build cache

###  What it NEVER touches:
 - Running containers (frontend, backend, proxy, db)
 - Named volumes (postgres data stays intact)
 - Any image currently used by a running container

## make nuke  —  full wipe, run when stack is down
### What it does:
  1. Stops and removes ALL containers in your stack
  2. Removes ALL named volumes (postgres data will be wiped, once we have the db container set up)
  3. Removes ALL images used by this stack (forces full rebuild)
  4. Prunes any remaining dangling images + build cache
### What it does NOT do:
  - It does not touch volumes or images from OTHER projects
    (use docker system prune -af --volumes for that)
  - It does not bring the stack back up (run `make up` after)
### After nuking:
  - `make up` will trigger full image rebuilds

## How to know when you need to run a clean command
### You have Dangling Images
When rebuilding containers with the `--no-cache` option you can find yourself with **dangling images** or "ghost containers" that take up space on your system for no reason. To check this run:
```
make ls
```

**Output Before Clean**
```
REPOSITORY               TAG       IMAGE ID       CREATED        SIZE
transcendence-backend    latest    27739e9d6958   18 hours ago   359MB
transcendence-frontend   latest    05f074b15691   18 hours ago   288MB
transcendence-proxy      latest    d4a8eca39288   18 hours ago   62.2MB
<none>                   <none>    328622a5b597   20 hours ago   62.2MB     <-------- dangling image
<none>                   <none>    828a57b00657   20 hours ago   359MB      <-------- dangling image
<none>                   <none>    7866fc3249c6   20 hours ago   288MB      <-------- dangling image
```
**Output After Clean**
```
REPOSITORY               TAG       IMAGE ID       CREATED             SIZE
transcendence-backend    latest    25573a47395a   About an hour ago   359MB
transcendence-frontend   latest    4ef4b8c20cb1   About an hour ago   288MB
transcendence-proxy      latest    1c16f9195d02   About an hour ago   62.2MB
```

### Docker Build Cache is Large
After time and building containers, etc. the docker build cache can often build up and use a lot of space on your system.
To get an idea of how much space Docker is taking up run:
```
docker system df
```
**Output Before Clean**
```
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          3         3         530.7MB   169.8MB (31%)
Containers      3         3         3.631MB   0B (0%)
Local Volumes   0         0         0B        0B
Build Cache     130       0         3.109GB   3.109GB    <------ This!
```
**Output After Clean**
```
TYPE            TOTAL     ACTIVE    SIZE      RECLAIMABLE
Images          3         0         530.7MB   530.7MB (100%)
Containers      0         0         0B        0B
Local Volumes   0         0         0B        0B
Build Cache     19        0         0B        0B
```

closes #31 