### PR TITLE
[Makefile] - Reworked dev setup, nuke cleanup, and guard `make up`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,3 @@ POSTGRES_DB=your_database_name#ex: postgresql
 POSTGRES_USER=your_db_superuser_name#ex: postgresql_superuser
 BACKEND_USER=your_backend_user_name#ex: backend_user
 DATABASE_URL=postgresql://$BACKEND_USER:$BACKEND_PW@db:5432/$POSTGRES_DB?schema=public#ex:DATABASE_URL=postgresql://backend_user:(password-from-backend_pw.txt)@db:5432/postgresql?schema=public
-JWT_SECRET=change-this-to-a-long-random-secret

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,3 @@ POSTGRES_VERSION=postgres_image_tag#ex: 18-alpine
 POSTGRES_DB=your_database_name#ex: postgresql
 POSTGRES_USER=your_db_superuser_name#ex: postgresql_superuser
 BACKEND_USER=your_backend_user_name#ex: backend_user
-DATABASE_URL=postgresql://$BACKEND_USER:$BACKEND_PW@db:5432/$POSTGRES_DB?schema=public#ex:DATABASE_URL=postgresql://backend_user:(password-from-backend_pw.txt)@db:5432/postgresql?schema=public

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SHOW_LOGS			= docker compose logs
 # ══════════════════════════════════════════════════════
 ##@ START STACK
 
-up: ##  Build and run all containers [DEV]
+up: setup ##  Build and run all containers [DEV]
 	@echo "$(GOLD)Building in Dev Mode$(RES)"
 	@docker compose -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) up -d
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -13,6 +13,9 @@ services:
   backend:
     build:
       target: dev
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+      - JWT_SECRET=${JWT_SECRET}
     volumes:
       - ./backend:/app                          # reflect host changes instantly
       - backend_node_modules:/app/node_modules  # prevent node_module overwrite in container

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,9 +30,6 @@ services:
     networks:
       - client-side
       - server-side
-    environment:
-      - DATABASE_URL=${DATABASE_URL}
-      - JWT_SECRET=${JWT_SECRET}
     secrets:
       - backend_pw
       - jwt_secret

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -20,10 +20,13 @@ clean: ## Remove dangling images, stopped containers, unused networks + build ca
 	@docker system df
 
 
-nuke: ## Full wipe — stops stack, removes volumes + images.
-	@echo "$(ORANGE)⚠️  This will destroy all containers, images, and volumes for this stack."
-	@echo "   Postgres data will be wiped.$(RES)"
-	@printf "   Continue? [y/N] " && read ans && [ "$$ans" = "y" ] || (echo "$(RED)   Aborted$(RES)" && exit 1)
+nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + secrets.
+	@echo "$(ORANGE)⚠️  This will destroy all containers, images, and volumes for this stack,"
+	@echo "$(RED)   AND:$(RES)"
+	@echo "   - The .env file"
+	@echo "   - All secret files"
+	@echo "   - All Postgres data"
+	@printf "$(CYAN)Continue? [y/N] $(RES)" && read ans && [ "$$ans" = "y" ] || (echo "$(RED)   Aborted$(RES)" && exit 1)
  
 	@echo ""
 	@echo "$(CYAN)<Stopping stack and removing containers + volumes>$(RES)"
@@ -40,6 +43,8 @@ nuke: ## Full wipe — stops stack, removes volumes + images.
 	@echo "$(CYAN)<Clearing all build cache>$(RES)"
 	@docker buildx prune -f
  
+	@echo "$(CYAN)<Removing .env and secret files>$(RES)"
+	@rm -f $(REQUIRED_FILES)
 	@echo ""
 	@echo "$(GREEN)Task completed. Everything is gone.$(RES)"
 	@echo "   Run \`make up\` to rebuild from scratch."

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -54,6 +54,10 @@ _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
 		sed -i "s|^$${key}=.*|$${key}=$${val}|" .env; \
 	done
 	@echo "$(GREEN)✓ Default values applied to .env$(RES)"
+	@for pair in $(DEV_ONLY_ENV_VARS); do \
+		echo "$$pair" >> .env; \
+	done
+	@echo "$(GREEN)✓ Dev-only vars appended to .env$(RES)"
 	@mkdir -p $(SECRETS_DIR)
 	@for pair in $(DEFAULT_SECRETS); do \
 		file=$$(echo "$$pair" | cut -d= -f1); \

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -36,15 +36,26 @@ REQUIRED_FILES = \
 
 ##@ FAST SETUP
 
-setup: ## Prompt to initialise .env and secrets — run automatically by 'make up'
-	@printf "$(CYAN)Build default setup?$(RES) [y/N]\n"
-	@printf "$(ORANGE)[Warning] This will overwrite your current '.env' and secrets$(RES)\n"
-	@printf "> "; read ans; \
+setup: ## Check required files; prompt for default setup only if any are missing
+	@missing=0; \
+	for f in $(REQUIRED_FILES); do \
+		if [ ! -f "$$f" ]; then \
+			echo "$(RED)✗ Missing required file: $$f$(RES)"; \
+			missing=1; \
+		fi; \
+	done; \
+	if [ "$$missing" -eq 0 ]; then \
+		echo "$(GREEN)✓ All required files present$(RES)"; \
+		exit 0; \
+	fi; \
+	echo "$(ORANGE)[Warning] Missing files detected.$(RES)"; \
+	printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
 	case "$$ans" in \
 		y|Y|yes|Yes|YES) \
 			$(MAKE) --no-print-directory _setup-apply ;; \
 		*) \
-			$(MAKE) --no-print-directory _check-missing ;; \
+			echo "$(RED)Aborted. Fix missing files manually before running \`make up\`.$(RES)"; \
+			exit 1 ;; \
 	esac
 
 _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
@@ -68,18 +79,4 @@ _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
 		echo "$(GREEN)✓ $(SECRETS_DIR)$$file created$(RES)"; \
 	done
 
-_check-missing: # Verify all required files exist; abort with warnings if any are missing
-	@missing=0; \
-	for f in $(REQUIRED_FILES); do \
-		if [ ! -f "$$f" ]; then \
-			echo "$(RED)✗ Missing required file: $$f$(RES)"; \
-			missing=1; \
-		fi; \
-	done; \
-	if [ "$$missing" -eq 1 ]; then \
-		echo "$(ORANGE)Run \`make setup\` to initialise missing files.$(RES)"; \
-		exit 1; \
-	fi; \
-	echo "$(GREEN)✓ All required files present$(RES)"
-
-.PHONY: setup _setup-apply _check-missing
+.PHONY: setup _setup-apply

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -16,7 +16,8 @@ DEFAULT_ENV_VARS = \
 # TODO: remove BACKEND_PW once backend reads password from /run/secrets/backend_pw
 DEV_ONLY_ENV_VARS = \
 	BACKEND_PW=changeme \
-	JWT_SECRET=jwt-changeme
+	JWT_SECRET=jwt-changeme \
+	DATABASE_URL=postgresql://backend_user:changeme@db:5432/transcendence?schema=public
 
 # ── Add new secrets here ───────────────────────────────────────────────────────
 # Format: filename=content   (file created at $(SECRETS_DIR)filename)

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -48,13 +48,12 @@ setup: ## Check required files; prompt for default setup only if any are missing
 		echo "$(GREEN)✓ All required files present$(RES)"; \
 		exit 0; \
 	fi; \
-	echo "$(ORANGE)[Warning] Missing files detected.$(RES)"; \
 	printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
 	case "$$ans" in \
 		y|Y|yes|Yes|YES) \
 			$(MAKE) --no-print-directory _setup-apply ;; \
 		*) \
-			echo "$(RED)Aborted. Fix missing files manually before running \`make up\`.$(RES)"; \
+			echo "$(RED)Aborted. Fix missing files manually by running $(GOLD)\`make setup\`$(RES)"; \
 			exit 1 ;; \
 	esac
 

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -59,18 +59,19 @@ setup: ## Check required files; prompt for default setup only if any are missing
 	esac
 
 _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
-	@grep -v '^\s*#' .env.example > .env
-	@echo "$(GREEN)✓ .env created from .env.example (comments stripped)$(RES)"
+	@{ \
+		for pair in $(DEV_ONLY_ENV_VARS); do \
+			echo "$$pair"; \
+		done; \
+		grep -v '^\s*#' .env.example; \
+	} > .env
+	@echo "$(GREEN)✓ .env created (dev-only vars prepended, comments stripped)$(RES)"
 	@for pair in $(DEFAULT_ENV_VARS); do \
 		key=$$(echo "$$pair" | cut -d= -f1); \
 		val=$$(echo "$$pair" | cut -d= -f2-); \
 		sed -i "s|^$${key}=.*|$${key}=$${val}|" .env; \
 	done
 	@echo "$(GREEN)✓ Default values applied to .env$(RES)"
-	@for pair in $(DEV_ONLY_ENV_VARS); do \
-		echo "$$pair" >> .env; \
-	done
-	@echo "$(GREEN)✓ Dev-only vars appended to .env$(RES)"
 	@mkdir -p $(SECRETS_DIR)
 	@for pair in $(DEFAULT_SECRETS); do \
 		file=$$(echo "$$pair" | cut -d= -f1); \

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -11,24 +11,26 @@ DEFAULT_ENV_VARS = \
 	POSTGRES_DB=transcendence \
 	POSTGRES_USER=postgres_superuser \
 	BACKEND_USER=backend_user \
-	JWT_SECRET=dev-jwt-secret-changeme
 
 # ── Dev-only vars not present in .env.example (appended to .env) ──────────────
 # TODO: remove BACKEND_PW once backend reads password from /run/secrets/backend_pw
 DEV_ONLY_ENV_VARS = \
-	BACKEND_PW=changeme
+	BACKEND_PW=changeme \
+	JWT_SECRET=jwt-changeme
 
 # ── Add new secrets here ───────────────────────────────────────────────────────
 # Format: filename=content   (file created at $(SECRETS_DIR)filename)
 DEFAULT_SECRETS = \
 	backend_pw.txt=changeme \
-	postgres_root_pw.txt=changeme
+	postgres_root_pw.txt=changeme \
+	jwt_secret.txt=jwt-changeme
 
 # ── Files that must exist before the stack can start ──────────────────────────
 REQUIRED_FILES = \
 	.env \
 	$(SECRETS_DIR)backend_pw.txt \
-	$(SECRETS_DIR)postgres_root_pw.txt
+	$(SECRETS_DIR)postgres_root_pw.txt \
+	$(SECRETS_DIR)jwt_secret.txt
 
 # ══════════════════════════════════════════════════════
 
@@ -46,8 +48,8 @@ setup: ## Prompt to initialise .env and secrets — run automatically by 'make u
 	esac
 
 _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
-	@cp .env.example .env
-	@echo "$(GREEN)✓ .env created from .env.example$(RES)"
+	@grep -v '^\s*#' .env.example > .env
+	@echo "$(GREEN)✓ .env created from .env.example (comments stripped)$(RES)"
 	@for pair in $(DEFAULT_ENV_VARS); do \
 		key=$$(echo "$$pair" | cut -d= -f1); \
 		val=$$(echo "$$pair" | cut -d= -f2-); \

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -13,6 +13,11 @@ DEFAULT_ENV_VARS = \
 	BACKEND_USER=backend_user \
 	JWT_SECRET=dev-jwt-secret-changeme
 
+# ── Dev-only vars not present in .env.example (appended to .env) ──────────────
+# TODO: remove BACKEND_PW once backend reads password from /run/secrets/backend_pw
+DEV_ONLY_ENV_VARS = \
+	BACKEND_PW=changeme
+
 # ── Add new secrets here ───────────────────────────────────────────────────────
 # Format: filename=content   (file created at $(SECRETS_DIR)filename)
 DEFAULT_SECRETS = \
@@ -30,7 +35,7 @@ REQUIRED_FILES = \
 ##@ FAST SETUP
 
 setup: ## Prompt to initialise .env and secrets — run automatically by 'make up'
-	@printf "$(GOLD)Run with defaults?$(RES) [y/N]\n"
+	@printf "$(CYAN)Build default setup?$(RES) [y/N]\n"
 	@printf "$(ORANGE)[Warning] This will overwrite your current '.env' and secrets$(RES)\n"
 	@printf "> "; read ans; \
 	case "$$ans" in \

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -2,37 +2,73 @@
 #               DEFAULT SETUP FOR DEV USE
 # ══════════════════════════════════════════════════════
 
-SECRETS_DIR				= secrets/
-BACKEND_PW_FILE			= backend_pw.txt
-POSTGRES_ROOT_PW_FILE	= postgres_root_pw.txt
+SECRETS_DIR = secrets/
+
+# ── Add new .env defaults here ────────────────────────────────────────────────
+# Format: KEY=value   (replaces the KEY=... line after copying .env.example)
+DEFAULT_ENV_VARS = \
+	POSTGRES_VERSION=18-alpine \
+	POSTGRES_DB=transcendence \
+	POSTGRES_USER=postgres_superuser \
+	BACKEND_USER=backend_user \
+	JWT_SECRET=dev-jwt-secret-changeme
+
+# ── Add new secrets here ───────────────────────────────────────────────────────
+# Format: filename=content   (file created at $(SECRETS_DIR)filename)
+DEFAULT_SECRETS = \
+	backend_pw.txt=changeme \
+	postgres_root_pw.txt=changeme
+
+# ── Files that must exist before the stack can start ──────────────────────────
+REQUIRED_FILES = \
+	.env \
+	$(SECRETS_DIR)backend_pw.txt \
+	$(SECRETS_DIR)postgres_root_pw.txt
+
+# ══════════════════════════════════════════════════════
 
 ##@ FAST SETUP
-setup: check-env create-secrets set-defaults-env ## Initialise all files needed to run the project (uses default values)
-	@echo "$(GREEN)✓ Setup complete. Run \`make up\` to start the stack.$(RES)"
 
-# ── .env ─────────────────────────────────────────────────────
-check-env: # Create .env from .env.example if it doesn't already exist
-	@if [ -f .env ]; then \
-		echo "$(CYAN)<.env already exists, skipping>$(RES)"; \
-	else \
-		cp .env.example .env; \
-		echo "$(GREEN)✓ .env created from .env.example$(RES)"; \
-	fi
+setup: ## Prompt to initialise .env and secrets — run automatically by 'make up'
+	@printf "$(GOLD)Run with defaults?$(RES) [y/N]\n"
+	@printf "$(ORANGE)[Warning] This will overwrite your current '.env' and secrets$(RES)\n"
+	@printf "> "; read ans; \
+	case "$$ans" in \
+		y|Y|yes|Yes|YES) \
+			$(MAKE) --no-print-directory _setup-apply ;; \
+		*) \
+			$(MAKE) --no-print-directory _check-missing ;; \
+	esac
 
-set-defaults-env: # Replaces placeholders for Key-Value pairs that need a valid value
-	@sed -i -e 's/postgres_image_tag #ex: 18-alpine/18-alpine/' .env
+_setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
+	@cp .env.example .env
+	@echo "$(GREEN)✓ .env created from .env.example$(RES)"
+	@for pair in $(DEFAULT_ENV_VARS); do \
+		key=$$(echo "$$pair" | cut -d= -f1); \
+		val=$$(echo "$$pair" | cut -d= -f2-); \
+		sed -i "s|^$${key}=.*|$${key}=$${val}|" .env; \
+	done
+	@echo "$(GREEN)✓ Default values applied to .env$(RES)"
+	@mkdir -p $(SECRETS_DIR)
+	@for pair in $(DEFAULT_SECRETS); do \
+		file=$$(echo "$$pair" | cut -d= -f1); \
+		content=$$(echo "$$pair" | cut -d= -f2-); \
+		echo "$$content" > $(SECRETS_DIR)$$file; \
+		echo "$(GREEN)✓ $(SECRETS_DIR)$$file created$(RES)"; \
+	done
 
-# ── Secrets ──────────────────────────────────────────────────
-create-secrets: backend-pw postgres-root-pw # Create default secret files if missing
+_check-missing: # Verify all required files exist; abort with warnings if any are missing
+	@missing=0; \
+	for f in $(REQUIRED_FILES); do \
+		if [ ! -f "$$f" ]; then \
+			echo "$(RED)✗ Missing required file: $$f$(RES)"; \
+			missing=1; \
+		fi; \
+	done; \
+	if [ "$$missing" -eq 1 ]; then \
+		echo "$(ORANGE)Run \`make setup\` to initialise missing files.$(RES)"; \
+		exit 1; \
+	fi; \
+	echo "$(GREEN)✓ All required files present$(RES)"
 
-backend-pw:
-	@mkdir -p secrets
-	@echo "changeme" > $(SECRETS_DIR)$(BACKEND_PW_FILE)
-	@echo "$(GREEN)✓ $(SECRETS_DIR)$(BACKEND_PW_FILE) created$(RES)"
-
-postgres-root-pw:
-	@mkdir -p secrets
-	@echo "changeme" > $(SECRETS_DIR)$(POSTGRES_ROOT_PW_FILE)
-	@echo "$(GREEN)✓ $(SECRETS_DIR)$(POSTGRES_ROOT_PW_FILE) created$(RES)"
-
-.PHONY: setup check-env set-defaults-env create-secrets backend-pw postgres-root-pw
+.PHONY: setup _setup-apply _check-missing


### PR DESCRIPTION
## What was done
- Rewrote `setup.mk` from scratch — declarative config, smarter check-before-prompt flow
- Added `DEV_ONLY_ENV_VARS` support so dev-only secrets stay out of `.env.example`
- `make up` now runs `setup` as a prerequisite — stack won't start with missing files
- `make nuke` now also deletes `.env` and all secret files, completing the full wipe
- `nuke` warning message updated to explicitly list what will be deleted
- Removed sensitive env vars from .env.example and compose.yaml
- Added sensitve (dev-only) env vars to compose.dev.yaml

closes #136 

## Why

Getting the stack running for the first time required too many manual steps — copying `.env.example`, filling in placeholders, creating secret files by hand. The goal was a zero-friction dev startup: clone, run `make up`, and the stack starts. Hardcoded defaults handle everything automatically, and the setup is modular enough that adding a new secret or env var is a one-liner. `make nuke` was also leaving stale config behind, which made it unreliable as a true reset tool.

## `setup.mk` rewrite

The old setup always recreated files and had a separate target per secret, making it brittle to extend. The new version defines required files, `.env` defaults, dev-only env vars, and secrets as **declarative lists** at the top of the file — adding new items requires only a one-line change to the relevant list.

`make setup` now **checks first**: it iterates over `REQUIRED_FILES` and lists anything missing. If all files are present, it exits silently. Only if something is missing does it ask whether to apply the default setup.

When the user confirms, `_setup-apply` runs — this **always recreates all required files from scratch**, regardless of which ones were actually missing. This is intentional: it guarantees a consistent, known-good state. `.env` is rebuilt from `.env.example` (comments stripped), dev-only vars are prepended, defaults are applied, and every secret file is overwritten with its default value.

## `make nuke` completes the full wipe

Previously `nuke` removed containers, images, and volumes, but left `.env` and secret files on disk. This meant re-running `make up` after a nuke would silently reuse stale config. Now `nuke` deletes everything listed in `REQUIRED_FILES`, so the state of the repo after a nuke is truly clean and `make up` will prompt for setup from scratch.

## How to test

**`make setup` / `make up`**
- With all required files present: `make up` should start the stack without prompting
- Delete one required file (e.g. `rm secrets/backend_pw.txt`) and run `make up` — it should list the missing file and ask if you want the default setup applied
- Answer `n` — it should abort with a message
- Answer `y` — it should recreate all missing files and then start the stack
- Run `make setup` directly when all files are present — should print `✓ All required files present` and exit

**`make nuke`**
- Run `make nuke` and confirm with `y`
- Verify containers, volumes, and images are removed (`make ps`, `docker image ls`)
- Verify `.env` and all files under `secrets/` are gone
- Run `make up` — it should detect missing files and prompt for default setup

## How to add required items to `make setup`

You can consult [this](https://github.com/team-Segfault-Society-42/Ft_transcendence/wiki/Environment-Variables-&-Secrets-%E2%80%94-Where-Does-It-Go%3F) wiki page for guidelines on how to achieve this.
