### PR TITLE
[GAME] Add finished game move history tracking and history endpoint

### DIFF
--- a/backend/src/modules/game/game.controller.ts
+++ b/backend/src/modules/game/game.controller.ts
@@ -14,4 +14,8 @@ export class GameController {
   getGame(@Param('id') gameId: string) {
     return this.gameService.getGameById(gameId);
   }
+  @Get(':id/history')
+  getFinishedGameHistory(@Param('id') gameId: string) {
+    return this.gameService.getFinishedGamesHistory(gameId);
+  }
 }

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -26,6 +26,7 @@ export function initGameState(): GameState {
     queuIdx: [],
     toDisapear: -1,
     lastMove: Date.now(),
+    movesGameHistory: [],
 
     players: {
       X: null,
@@ -123,6 +124,7 @@ export function applyMove(game: GameState, r: number, c: number): GameState {
   game.board[r][c] = symbol;
   game.moveCount++;
   game.queuIdx.push({ r, c });
+  game.movesGameHistory.push(r * 3 + c);
   // DEBUG : state before add
   console.log('--- QUEUE APRES AJOUT ---');
   console.table(game.queuIdx);

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -226,6 +226,7 @@ export function resetBoardForReplay(game: GameState): GameState {
   game.queuIdx = [];
   game.toDisapear = -1;
   game.lastMove = Date.now();
+  game.movesGameHistory = [];
 
   game.replayVotes = {
     X: false,

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -34,7 +34,19 @@ export class GameService {
     if (!game) throw new NotFoundException(`Game with ID ${gameId} not found`);
     return structuredClone(game);
   }
-  // maybe prepare more for 6x6 , 7x7 or 9x9
+
+  getFinishedGamesHistory(gameId: string) {
+    const game = this.getMutableGameById(gameId);
+
+    if (game.status !== 'finished') throw new Error('Game not finished yet');
+
+    return {
+      gameId,
+      movesGameHistory: [...game.movesGameHistory],
+      winner: game.winner,
+      endReason: game.endReason,
+    };
+  }
 
   joinGame(
     gameId: string,

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -8,6 +8,8 @@ export type EndReason = 'win' | 'draw' | 'timeout' | 'forfeit' | null;
 
 export type PlayerRole = PlayerSymbol | 'spectator';
 
+export type MovesGameHistory = number[];
+
 export interface PublicPlayerProfile {
   id: number;
   username: string;
@@ -61,4 +63,5 @@ export interface GameState {
   scores: ScoreBoard;
   replayVotes: ReplayState;
   playerProfiles: PlayerProfilesInGame;
+  movesGameHistory: MovesGameHistory;
 }

--- a/frontend/src/type/game.types.ts
+++ b/frontend/src/type/game.types.ts
@@ -8,6 +8,8 @@ export type EndReason = "win" | "draw" | "timeout" | "forfeit" | null;
 
 export type PlayerRole = PlayerSymbol | "spectator";
 
+export type MovesGameHistory = number[];
+
 export interface PublicPlayerProfile {
   id: number;
   username: string;
@@ -61,4 +63,5 @@ export interface GameState {
   scores: ScoreBoard;
   replayVotes: ReplayState;
   playerProfiles: PlayerProfilesInGame;
+  movesGameHistory: MovesGameHistory;
 }


### PR DESCRIPTION
## Summary

This PR adds move history tracking for finished games and exposes a dedicated endpoint to retrieve that history.

The goal is to preserve the sequence of played moves for a game and make it available once the match is over, together with the final outcome metadata.

This is a small backend-focused step toward features such as:
- post-game recap
- replay UI
- match history display
- future persistence/statistics work

---

## What was implemented

### Backend game state
- added `movesGameHistory` to `GameState`
- added `MovesGameHistory` type
- initialized `movesGameHistory` in `initGameState()`

### Move recording
- each played move is now appended to `movesGameHistory` inside `applyMove()`
- moves are stored in play order using board index format (`r * 3 + c`)

### Replay reset
- `movesGameHistory` is cleared in `resetBoardForReplay()`

### Service layer
- added `getFinishedGamesHistory(gameId)` in `GameService`
- returns:
  - `gameId`
  - `movesGameHistory`
  - `winner`
  - `endReason`

### Controller
- added `GET /game/:id/history`

### Shared typing
- synced related types in:
  - `backend/src/modules/game/game.types.ts`
  - `frontend/src/type/game.types.ts`

---

## API behavior

### New endpoint
```http
GET /game/:id/history