### PR TITLE
[BACKEND] Configure Swagger (OpenAPI) for interactive API documentation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.17",
         "@nestjs/websockets": "^11.1.17",
+        "@nestjs/swagger": "^11.2.6",
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
         "bcrypt": "^6.0.0",
@@ -24,7 +25,8 @@
         "pg": "^8.20.0",
         "prisma": "^7.5.0",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -2138,6 +2140,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@mrleebo/prisma-ast": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
@@ -2602,6 +2610,59 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.16",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.16.tgz",
@@ -2893,6 +2954,13 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -4322,7 +4390,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7944,7 +8011,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8176,7 +8242,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -10361,6 +10426,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.17",
     "@nestjs/websockets": "^11.1.17",
+    "@nestjs/swagger": "^11.2.6",
     "@prisma/adapter-pg": "^7.5.0",
     "@prisma/client": "^7.5.0",
     "bcrypt": "^6.0.0",
@@ -35,7 +36,8 @@
     "pg": "^8.20.0",
     "prisma": "^7.5.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+	constructor(private readonly appService: AppService) {}
 
-  @Get('hello')
-  getHello() {
-    return this.appService.getHello();
-  }
+	@ApiOperation({ summary: 'Get simple message from backend' })
+	@Get('hello')
+	getHello() {
+		return this.appService.getHello();
+	}
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -4,47 +4,83 @@ import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-	constructor(private readonly authService: AuthService) {}
+		constructor(private readonly authService: AuthService) {}
 
-	@Post('register')
-	register(@Body() registerDto: RegisterDto) {
-		return this.authService.register(registerDto);
-	}
+		@ApiOperation({ summary: 'Register a new user' })
+		@ApiBody({ type: RegisterDto })
+		@ApiResponse({
+				status: 201,
+				description: 'User registered successfully',
+		})
+		@ApiResponse({
+				status: 400,
+				description: 'Invalid input data',
+		})
+		@Post('register')
+		register(@Body() registerDto: RegisterDto) {
+				return this.authService.register(registerDto);
+		}
 
-	@Post('login')
-	async login(
-		@Body() loginDto: LoginDto,
-		@Res({ passthrough: true }) res: Response,
-	) {
-		const { access_token } = await this.authService.login(loginDto);
+		@ApiOperation({ summary: 'Log in a user and set an HttpOnly JWT cookie' })
+		@ApiBody({ type: LoginDto })
+		@ApiResponse({
+				status: 201,
+				description: 'Login successful',
+		})
+		@ApiResponse({
+				status: 401,
+				description: 'Invalid credentials',
+		})
+		@Post('login')
+		async login(
+				@Body() loginDto: LoginDto,
+				@Res({ passthrough: true }) res: Response,
+		) {
+				const { access_token } = await this.authService.login(loginDto);
 
-		res.cookie('access_token', access_token, {
-			httpOnly: true,
-			secure: false,
-			sameSite: 'lax',
-			maxAge: 60 * 60 * 1000,
-		});
+				res.cookie('access_token', access_token, {
+						httpOnly: true,
+						secure: false,
+						sameSite: 'lax',
+						maxAge: 60 * 60 * 1000,
+				});
 
-		return { message: 'Login successful' };
-	}
+				return { message: 'Login successful' };
+		}
 
-	@Post('logout')
-	logout(@Res({ passthrough: true }) res: Response) {
-		res.clearCookie('access_token', {
-			httpOnly: true,
-			secure: false,
-			sameSite: 'lax',
-		});
+		@ApiOperation({ summary: 'Log out the current user and clear the auth cookie' })
+		@ApiResponse({
+				status: 201,
+				description: 'Logout successful',
+		})
+		@Post('logout')
+		logout(@Res({ passthrough: true }) res: Response) {
+				res.clearCookie('access_token', {
+						httpOnly: true,
+						secure: false,
+						sameSite: 'lax',
+				});
 
-		return { message: 'Logout successful' };
-	}
+				return { message: 'Logout successful' };
+		}
 
-	@UseGuards(JwtAuthGuard)
-	@Get('me')
-	me(@Req() req) {
-		return this.authService.me(req.user.sub);
-	}
+		@ApiOperation({ summary: 'Get the currently authenticated user' })
+		@ApiResponse({
+				status: 200,
+				description: 'Authenticated user returned successfully',
+		})
+		@ApiResponse({
+				status: 401,
+				description: 'Unauthorized',
+		})
+		@UseGuards(JwtAuthGuard)
+		@Get('me')
+		me(@Req() req) {
+				return this.authService.me(req.user.sub);
+		}
 }

--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,10 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
-	@IsEmail()
-	email: string;
+		@ApiProperty({
+				example: 'nico@example.com',
+				description: 'User email address',
+		})
+		@IsEmail()
+		email: string;
 
-	@IsString()
-	@MinLength(6)
-	password: string;
+		@ApiProperty({
+				example: 'secret123',
+				description: 'User password',
+				minLength: 6,
+		})
+		@IsString()
+		@MinLength(6)
+		password: string;
 }

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,22 +1,44 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
 
 export class RegisterDto {
-	@IsEmail()
-	email: string;
+		@ApiProperty({
+				example: 'nico@example.com',
+				description: 'User email address',
+		})
+		@IsEmail()
+		email: string;
 
-	@IsString()
-	@MinLength(6)
-	password: string;
+		@ApiProperty({
+				example: 'secret123',
+				description: 'User password',
+				minLength: 6,
+		})
+		@IsString()
+		@MinLength(6)
+		password: string;
 
-	@IsString()
-	@MinLength(1)
-	username: string;
+		@ApiProperty({
+				example: 'nico42',
+				description: 'Unique username',
+		})
+		@IsString()
+		@MinLength(1)
+		username: string;
 
-	@IsOptional()
-	@IsString()
-	bio?: string;
+		@ApiPropertyOptional({
+				example: 'I like Pong and backend development.',
+				description: 'Optional user biography',
+		})
+		@IsOptional()
+		@IsString()
+		bio?: string;
 
-	@IsOptional()
-	@IsString()
-	avatar?: string;
+		@ApiPropertyOptional({
+				example: 'default.png',
+				description: 'Optional avatar filename or URL',
+		})
+		@IsOptional()
+		@IsString()
+		avatar?: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -21,6 +21,7 @@ async function bootstrap() {
 		.setTitle('ft_transcendence API')
 		.setDescription('API documentation for ft_transcendence backend')
 		.setVersion('1.0')
+		.addServer('/api')
 		.build();
 
 	const document = SwaggerModule.createDocument(app, config);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -9,13 +10,21 @@ async function bootstrap() {
   app.enableCors();
   app.use(cookieParser());
 
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      transform: true,
-    }),
-  );
+	app.useGlobalPipes(
+	new ValidationPipe({
+		whitelist: true,
+		forbidNonWhitelisted: true,
+		transform: true,
+		}),
+	);
+	const config = new DocumentBuilder()
+		.setTitle('ft_transcendence API')
+		.setDescription('API documentation for ft_transcendence backend')
+		.setVersion('1.0')
+		.build();
+
+	const document = SwaggerModule.createDocument(app, config);
+	SwaggerModule.setup('api-docs', app, document);
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,24 +1,27 @@
 import { Controller, Param, ParseIntPipe, Body, Get, Patch } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UpdateUserDto} from './dto/update-user.dto';
-// import { CreateUserDto } from './dto/create-user.dto';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
-// @UseGuards(AuthGuard) // TODO later with AUTH
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
 
 	constructor(private usersService: UsersService) {}
 
+	@ApiOperation({ summary: 'Get all users' })
 	@Get()
 	getUsers() {
 		return this.usersService.getUsers();
 	}
 
+	@ApiOperation({ summary: 'Get user by ID' })
 	@Get(':id')
 	getUser(@Param('id', ParseIntPipe) id: number) {
 		return this.usersService.getUser(id);
 	}
 
+	@ApiOperation({ summary: 'Update user' })
 	@Patch(':id')
 	updateUser(
 		@Param('id', ParseIntPipe) id: number,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -27,10 +27,6 @@ export class UsersController {
 		return this.usersService.updateUser(id, updateUserDto);
 	}
 
-	// @Post()
-	// createUser(@Body() createUserDto: CreateUserDto) {
-	// 	return this.usersService.createUser(createUserDto);
-	// }
 }
 
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -70,28 +70,4 @@ export class UsersService {
 			throw new BadRequestException('Failed to update user');
 		}
 	}
-
-	// async createUser(createUserDto: CreateUserDto) {
-	// 	try {
-	// 		return await this.prisma.user.create({
-	// 			data: {
-	// 				username: createUserDto.username,
-	// 				bio: createUserDto.bio ?? '',
-	// 				avatar: createUserDto.avatar ?? 'default.png',
-	// 				wins: 0,
-	// 				losses: 0,
-	// 				draws: 0,
-	// 			},
-	// 		});
-	// 	} catch (error) {
-	// 		if (
-	// 			error instanceof Prisma.PrismaClientKnownRequestError &&
-	// 			error.code === 'P2002'
-	// 		) {
-	// 			throw new ConflictException('Username already exists');
-	// 		}
-
-	// 		throw new BadRequestException('Failed to create user');
-	// 	}
-	// }
 }


### PR DESCRIPTION


## Summary

This PR adds **Swagger / OpenAPI** documentation to the NestJS backend and completes the related Swagger setup work.

It introduces a browser-accessible interactive documentation page for the backend API and documents the current main routes so they are easier to inspect and test during development.

This PR also handles an important infrastructure detail in the current stack: the backend is exposed publicly through nginx under the `/api` prefix, so Swagger was configured with the correct server base path to make route execution work from the UI.

---

## What was done

## 1. Installed Swagger dependencies

Added the required backend dependencies:

* `@nestjs/swagger`
* `swagger-ui-express`

### Why

These packages allow NestJS to generate an OpenAPI document and expose the interactive Swagger UI.

---

## 2. Added global Swagger setup in `main.ts`

Configured Swagger at application bootstrap level.

### What was added

* Swagger document builder
* API title, description, and version
* document generation through `SwaggerModule.createDocument(...)`
* Swagger UI route setup

### Why

Swagger is a global concern because it documents the API surface of the whole Nest application, not a single module.

---

## 3. Configured the Swagger server base path for nginx

Added:

```ts
.addServer('/api')
```

to the Swagger document configuration.

### Problem

The backend is publicly exposed through nginx under:

```txt
/api/...
```

but Nest internally registers routes without that external prefix.

Without this server configuration, Swagger UI generated execution requests such as:

```txt
/auth/register
```

instead of:

```txt
/api/auth/register
```

which caused `404 Not Found` when testing routes from the docs page.

### Fix

Configured Swagger with the `/api` base path so generated request URLs now match the real public backend path.

---

## 4. Added Swagger decorators to auth DTOs

Documented:

* `RegisterDto`
* `LoginDto`

### What was added

* `@ApiProperty(...)`
* `@ApiPropertyOptional(...)`
* example values
* field descriptions
* required vs optional field metadata

### Why

This makes request bodies visible and usable inside Swagger UI while keeping validation and documentation aligned in the DTO layer.

---

## 5. Documented auth endpoints in `AuthController`

Added controller-level Swagger decorators for:

* `POST /auth/register`
* `POST /auth/login`
* `POST /auth/logout`
* `GET /auth/me`

### What was added

* `@ApiTags('Auth')`
* `@ApiOperation(...)`
* `@ApiBody(...)`
* `@ApiResponse(...)`

### Why

The DTOs describe request data, while the controller describes endpoint behavior such as purpose and expected response codes.

---

## 6. Added Swagger grouping and summaries for other visible endpoints

### Users

Added:

* `@ApiTags('Users')`
* light `@ApiOperation(...)` summaries for users endpoints

### App

Added:

* a clear Swagger summary for the simple backend hello endpoint

### Why

This keeps the docs readable and grouped without over-investing time in full response modeling for every route.

---

## Important file-level changes

## Backend bootstrap

* `backend/src/main.ts`

  * add global Swagger setup
  * add `/api` Swagger server base path

## Auth DTOs

* `backend/src/auth/dto/register.dto.ts`

  * add Swagger field metadata
* `backend/src/auth/dto/login.dto.ts`

  * add Swagger field metadata

## Auth controller

* `backend/src/auth/auth.controller.ts`

  * add tags, operation summaries, request body docs, response docs

## Users controller

* `backend/src/users/users.controller.ts`

  * add tag + light summaries

## App controller

* `backend/src/app.controller.ts`

  * add endpoint summary

---

## Problems addressed

## 1. No interactive backend documentation

### Problem

The backend routes existed but were not visible/testable through a single documentation UI.

### Fix

Added Swagger UI and OpenAPI document generation.

---

## 2. Swagger execution failed behind nginx

### Problem

Swagger generated request URLs without the external `/api` prefix used by nginx.

### Fix

Added Swagger server base path configuration with `.addServer('/api')`.

---

## 3. Auth request bodies were unclear in Swagger

### Problem

Swagger could see the routes, but request body examples and field descriptions were incomplete.

### Fix

Added Swagger decorators to auth DTOs.

---

## 4. Endpoint intent was not explicit in the docs

### Problem

Swagger listed routes, but summaries and expected response information were missing.

### Fix

Added controller-level Swagger decorators to auth and light summaries for users/app routes.

---

## How to test

## 0. Start the stack

```bash
make nuke
make up
```

Expected:

* postgres starts correctly
* backend starts correctly
* nginx proxy is available on port `1024`

---

## 1. Open Swagger UI

Open in browser:

```txt
http://localhost:1024/api/api-docs
```

Expected:

* Swagger UI page loads correctly
* grouped sections such as `Auth`, `Users`, and `App` are visible

---

## 2. Verify DTO-based request bodies are visible

In Swagger UI:

* open `POST /auth/register`
* open `POST /auth/login`

Expected:

* request body examples are prefilled
* auth DTO fields are clearly documented
* optional fields are marked correctly

---

## 3. Execute register from Swagger UI

Use `POST /auth/register` with the generated example body or adjusted values.

Expected:

* request goes to `/api/auth/register`
* no `404` from missing `/api` prefix
* backend returns a valid registration response

---

## 4. Execute login from Swagger UI

Use `POST /auth/login` with valid credentials.

Expected:

* request succeeds
* response is documented and visible in Swagger UI

---

## 5. Verify docs grouping/readability

Expected:

* `Auth` endpoints grouped together
* `Users` endpoints grouped together
* app hello endpoint has a clear summary

---

## Real result from this branch

The Swagger documentation is now reachable through:

```txt
http://localhost:1024/api/api-docs
```

and executable requests correctly use the nginx public API prefix.

---

## Result

Backend now has:

* interactive API documentation
* DTO-driven request body documentation
* controller-level endpoint summaries/responses for auth
* correct Swagger execution behind nginx
* cleaner API visibility for development and testing

---

## Notes / current limitations

* this PR focuses on first-level Swagger integration, not exhaustive OpenAPI modeling
* cookie-based auth behavior is documented at a basic level but not fully modeled in Swagger yet
* advanced auth documentation and richer response schemas can be added later if needed

---

## Next steps

* optionally document more routes in deeper detail if future frontend/backend work needs it
* consider broader auth architecture improvements later if needed
* move on to the next backend feature after this documentation milestone

---

closes #161 
