### PR TITLE
[BACKEND][AUTH] Apply JwtAuthGuard globally with @Public() for auth routes

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,86 +1,89 @@
-import { Body, Controller, Post, Get, UseGuards, Req, Res } from '@nestjs/common';
+import { Body, Controller, Post, Get, Req, Res } from '@nestjs/common';
 import type { Response } from 'express';
+import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
-import { JwtAuthGuard } from './jwt-auth.guard';
-import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Public } from './public.decorator';
+import type { AuthRequest } from './jwt-auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-		constructor(private readonly authService: AuthService) {}
+	constructor(private readonly authService: AuthService) {}
 
-		@ApiOperation({ summary: 'Register a new user' })
-		@ApiBody({ type: RegisterDto })
-		@ApiResponse({
-				status: 201,
-				description: 'User registered successfully',
-		})
-		@ApiResponse({
-				status: 400,
-				description: 'Invalid input data',
-		})
-		@Post('register')
-		register(@Body() registerDto: RegisterDto) {
-				return this.authService.register(registerDto);
-		}
+	@Public()
+	@ApiOperation({ summary: 'Register a new user' })
+	@ApiBody({ type: RegisterDto })
+	@ApiResponse({
+		status: 201,
+		description: 'User registered successfully',
+	})
+	@ApiResponse({
+		status: 400,
+		description: 'Invalid input data',
+	})
+	@Post('register')
+	register(@Body() registerDto: RegisterDto) {
+		return this.authService.register(registerDto);
+	}
 
-		@ApiOperation({ summary: 'Log in a user and set an HttpOnly JWT cookie' })
-		@ApiBody({ type: LoginDto })
-		@ApiResponse({
-				status: 201,
-				description: 'Login successful',
-		})
-		@ApiResponse({
-				status: 401,
-				description: 'Invalid credentials',
-		})
-		@Post('login')
-		async login(
-				@Body() loginDto: LoginDto,
-				@Res({ passthrough: true }) res: Response,
-		) {
-				const { access_token } = await this.authService.login(loginDto);
+	@Public()
+	@ApiOperation({ summary: 'Log in a user and set an HttpOnly JWT cookie' })
+	@ApiBody({ type: LoginDto })
+	@ApiResponse({
+		status: 201,
+		description: 'Login successful',
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Invalid credentials',
+	})
+	@Post('login')
+	async login(
+		@Body() loginDto: LoginDto,
+		@Res({ passthrough: true }) res: Response,
+	) {
+		const { access_token } = await this.authService.login(loginDto);
 
-				res.cookie('access_token', access_token, {
-						httpOnly: true,
-						secure: false,
-						sameSite: 'lax',
-						maxAge: 60 * 60 * 1000,
-				});
+		res.cookie('access_token', access_token, {
+			httpOnly: true,
+			secure: false,
+			sameSite: 'lax',
+			maxAge: 60 * 60 * 1000,
+		});
 
-				return { message: 'Login successful' };
-		}
+		return { message: 'Login successful' };
+	}
 
-		@ApiOperation({ summary: 'Log out the current user and clear the auth cookie' })
-		@ApiResponse({
-				status: 201,
-				description: 'Logout successful',
-		})
-		@Post('logout')
-		logout(@Res({ passthrough: true }) res: Response) {
-				res.clearCookie('access_token', {
-						httpOnly: true,
-						secure: false,
-						sameSite: 'lax',
-				});
+	@Public()
+	@ApiOperation({ summary: 'Log out the current user and clear the auth cookie' })
+	@ApiResponse({
+		status: 201,
+		description: 'Logout successful',
+	})
+	@Post('logout')
+	logout(@Res({ passthrough: true }) res: Response) {
+		res.clearCookie('access_token', {
+			httpOnly: true,
+			secure: false,
+			sameSite: 'lax',
+		});
 
-				return { message: 'Logout successful' };
-		}
+		return { message: 'Logout successful' };
+	}
 
-		@ApiOperation({ summary: 'Get the currently authenticated user' })
-		@ApiResponse({
-				status: 200,
-				description: 'Authenticated user returned successfully',
-		})
-		@ApiResponse({
-				status: 401,
-				description: 'Unauthorized',
-		})
-		@UseGuards(JwtAuthGuard)
-		@Get('me')
-		me(@Req() req) {
-				return this.authService.me(req.user.sub);
-		}
+	@ApiOperation({ summary: 'Get the currently authenticated user' })
+	@ApiResponse({
+		status: 200,
+		description: 'Authenticated user returned successfully',
+	})
+	@ApiResponse({
+		status: 401,
+		description: 'Unauthorized',
+	})
+	@Get('me')
+	me(@Req() req: AuthRequest) {
+		return this.authService.me(req.user.sub);
+	}
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
 	imports: [

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -3,13 +3,24 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Module({
-	imports: [JwtModule.register({
-		secret: process.env.JWT_SECRET,
-		signOptions: { expiresIn: '1h' },
-	}),PrismaModule],
+	imports: [
+		JwtModule.register({
+			secret: process.env.JWT_SECRET,
+			signOptions: { expiresIn: '1h' },
+		}),
+		PrismaModule,
+	],
 	controllers: [AuthController],
-	providers: [AuthService],
+	providers: [
+		AuthService,
+		JwtAuthGuard,
+		{
+			provide: APP_GUARD,
+			useClass: JwtAuthGuard,
+		},
+	],
 })
 export class AuthModule {}

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -5,39 +5,55 @@ import {
 	UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { Socket } from 'socket.io';
-import { Request } from 'express'
+import { Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import type { Socket } from 'socket.io';
+import { IS_PUBLIC_KEY } from './public.decorator';
 
 export interface JwtPayload {
-	sub: number
-	email: string
+	sub: number;
+	email: string;
 }
 
 export interface AuthRequest extends Request {
-	user:JwtPayload
+	user: JwtPayload;
+	cookies?: {
+		access_token?: string;
+		[key: string]: string | undefined;
+	};
 }
 
 export type AuthSocket = Socket & {
 	data: {
-		user:JwtPayload
-	}
-}
+		user: JwtPayload;
+	};
+};
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
-	constructor(private jwtService: JwtService) {}
+	constructor(
+		private readonly jwtService: JwtService,
+		private readonly reflector: Reflector,
+	) {}
 
 	async canActivate(context: ExecutionContext): Promise<boolean> {
-		let token: string | undefined
+		const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+			context.getHandler(),
+			context.getClass(),
+		]);
 
-		if (context.getType() === "http") {
+		if (isPublic) {
+			return true;
+		}
 
-			const request = context.switchToHttp().getRequest();
-			token = this.extractTokenFromRequest(request);
-		} 
-		else if (context.getType() === "ws") {
+		const contextType = context.getType<'http' | 'ws'>();
+		let token: string | undefined;
 
-			const client = context.switchToWs().getClient()
+		if (contextType === 'http') {
+			const request = context.switchToHttp().getRequest<AuthRequest>();
+			token = this.extractTokenFromHttpRequest(request);
+		} else if (contextType === 'ws') {
+			const client = context.switchToWs().getClient<AuthSocket>();
 			token = this.extractTokenFromWs(client);
 		}
 
@@ -46,63 +62,42 @@ export class JwtAuthGuard implements CanActivate {
 		}
 
 		try {
-			const payload = await this.jwtService.verifyAsync(token);
+			const payload = await this.jwtService.verifyAsync<JwtPayload>(token);
 
-			if (context.getType() === "http") {
-
-				context.switchToHttp().getRequest().user = payload;
+			if (contextType === 'http') {
+				const request = context.switchToHttp().getRequest<AuthRequest>();
+				request.user = payload;
+			} else if (contextType === 'ws') {
+				const client = context.switchToWs().getClient<AuthSocket>();
+				client.data.user = payload;
 			}
-			else if (context.getType() === 'ws') {
 
-				context.switchToWs().getClient().data.user = payload;
-
-			}
 			return true;
 		} catch {
 			throw new UnauthorizedException('Invalid or expired token');
 		}
 	}
 
-	private extractTokenFromRequest(request: any): string | undefined {
-		const cookieToken = request.cookies?.access_token;
+	private extractTokenFromHttpRequest(request: AuthRequest): string | undefined {
+		return request.cookies?.access_token;
+	}
 
-		if (cookieToken) {
-			return cookieToken;
+	private extractTokenFromWs(client: AuthSocket): string | undefined {
+		const rawCookies = client.handshake.headers.cookie;
+
+		if (!rawCookies) {
+			return undefined;
 		}
 
-		return this.extractTokenFromHeader(request);
-	}
-
-	private extractTokenFromHeader(request: any): string | undefined {
-		const authHeader = request.headers['authorization'];
-
-		if (!authHeader) return undefined;
-
-		const [type, token] = authHeader.split(' ');
-
-		if (type !== 'Bearer') return undefined;
-
-		return token;
-	}
-
-	private extractTokenFromWs(client: any): string | undefined {
-		const headerToken = this.extractTokenFromHeader(client.handshake)
-		if (headerToken)
-			return headerToken
-
-		const rawCookies = client.handshake.headers.cookie
-		if (!rawCookies)
-			return undefined
-
-		const cookies = rawCookies.split(';')
-		console.log('Cookies reçus du client:', client.handshake.headers.cookie);
-		for (const cookie of cookies) {
-			const [key, value] = cookie.trim().split('=')
+		for (const cookie of rawCookies.split(';')) {
+			const [key, ...valueParts] = cookie.trim().split('=');
+			const value = valueParts.join('=');
 
 			if (key === 'access_token' && value) {
-				return value
+				return decodeURIComponent(value);
 			}
 		}
-		return undefined
+
+		return undefined;
 	}
 }

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -17,10 +17,6 @@ export interface JwtPayload {
 
 export interface AuthRequest extends Request {
 	user: JwtPayload;
-	cookies?: {
-		access_token?: string;
-		[key: string]: string | undefined;
-	};
 }
 
 export type AuthSocket = Socket & {
@@ -78,7 +74,7 @@ export class JwtAuthGuard implements CanActivate {
 		}
 	}
 
-	private extractTokenFromHttpRequest(request: AuthRequest): string | undefined {
+	private extractTokenFromHttpRequest(request: Request): string | undefined {
 		return request.cookies?.access_token;
 	}
 

--- a/backend/src/auth/jwt-auth.guard.ts
+++ b/backend/src/auth/jwt-auth.guard.ts
@@ -54,6 +54,7 @@ export class JwtAuthGuard implements CanActivate {
 		}
 
 		if (!token) {
+			if (contextType === 'ws') return false;
 			throw new UnauthorizedException('Missing authentication token');
 		}
 
@@ -70,6 +71,7 @@ export class JwtAuthGuard implements CanActivate {
 
 			return true;
 		} catch {
+			if (contextType === 'ws') return false;
 			throw new UnauthorizedException('Invalid or expired token');
 		}
 	}

--- a/backend/src/auth/public.decorator.ts
+++ b/backend/src/auth/public.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -4,6 +4,7 @@ import { UpdateUserDto} from './dto/update-user.dto';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 
 @ApiTags('Users')
+
 @Controller('users')
 export class UsersController {
 


### PR DESCRIPTION
## Summary

This PR closes **#163** by moving authentication from manual route protection to a **global guard model with explicit public routes**.

---

## Key change

```txt
Before → public by default
After  → protected by default
```

---

## What changed

### Global Guard

* `JwtAuthGuard` registered using `APP_GUARD`
* applies to ALL routes

### Public decorator

* `@Public()` added
* used for:

  * register
  * login
  * logout

### Controller cleanup

* removed `@UseGuards`
* `/auth/me` now protected automatically

---

## Behavior before vs after

### Before

```bash
curl http://localhost:1024/api/users
```

✅ Returned:

```json
[...users...]
```

---

### After

```bash
curl -i http://localhost:1024/api/users
```

❌ Returns:

```json
401 Unauthorized
```

---

## How to test

### 1. Protected route (no auth)

```bash
curl -i http://localhost:1024/api/users
```

Expected:

```json
401 Unauthorized
```

---

### 2. Register (public)

```bash
curl -i -X POST http://localhost:1024/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"secret12","username":"testuser"}'
```

Expected:

```json
201 Created + user data
```

---

### 3. Login (store cookie)

```bash
curl -i -c cookies.txt -X POST http://localhost:1024/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"secret12"}'
```

Expected:

```txt
Set-Cookie: access_token=...
```

---

### 4. Access protected route WITHOUT cookie

```bash
curl -i http://localhost:1024/api/auth/me
```

Expected:

```json
401 Unauthorized
```

---

### 5. Access WITH cookie

```bash
curl -i -b cookies.txt http://localhost:1024/api/auth/me
```

Expected:

```json
200 OK + user data
```

---

### 6. Access `/users` with auth

```bash
curl -i -b cookies.txt http://localhost:1024/api/users
```

Expected:

```json
200 OK + users list
```

---

### 7. Logout

```bash
curl -i -b cookies.txt -c cookies.txt -X POST http://localhost:1024/api/auth/logout
```

Expected:

```txt
cookie cleared
```

---

### 8. Test again

```bash
curl -i -b cookies.txt http://localhost:1024/api/users
```

Expected:

```json
401 Unauthorized
```

---

## Additional Notes (merge + design decisions)

### Cookie-based authentication (HTTP)

The guard now enforces a **cookie-based authentication model** for HTTP requests:

* JWT is read from `access_token` HttpOnly cookie
* removed `Authorization: Bearer` fallback for HTTP to keep a **single consistent auth flow**

This aligns with the current frontend behavior and simplifies the security model.

---

### WebSocket support

The guard preserves compatibility with WebSocket authentication:

* token is extracted from the handshake cookies
* authenticated user is attached to `client.data.user`

---

### Secure cookie flag

```ts
secure: false
```

* kept for local development (HTTP)
* will be moved to an environment-based configuration when HTTPS is enabled in production

---

### Code cleanup

* removed debug logging from JWT guard
* removed obsolete comments in `users.controller.ts`
* improved type safety with explicit `JwtPayload`, `AuthRequest`, and `AuthSocket`

---

## Result

* secure-by-default backend
* explicit public routes
* cleaner and more maintainable auth logic
* consistent cookie-based authentication model
* ready for future extensions (OAuth, WS auth)

---

closes #163

