### PR TITLE
[INFRA] - Inject `NODE_ENV=production` into backend and apply `Secure` cookie flag conditionally

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -48,7 +48,7 @@ export class AuthController {
 
 		res.cookie('access_token', access_token, {
 			httpOnly: true,
-			secure: false,
+			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 			maxAge: 60 * 60 * 1000,
 		});
@@ -66,7 +66,7 @@ export class AuthController {
 	logout(@Res({ passthrough: true }) res: Response) {
 		res.clearCookie('access_token', {
 			httpOnly: true,
-			secure: false,
+			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 		});
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -9,6 +9,8 @@ services:
   backend:
     build:
       target: prod    # targets the prod stage in a multi-stage Dockerfile
+    environment:
+      - NODE_ENV=production
  
   # ── Reverse Proxy (Nginx) ────────────────────────────────────────
   proxy:


### PR DESCRIPTION
Closes #171 

## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

**Infrastructure:**

- Added `NODE_ENV=production` to the `backend` service in `compose.prod.yaml`

**Backend:**

- Replaced `secure: false` with `secure: process.env.NODE_ENV === 'production'` on the login `Set-Cookie` call in `auth.controller.ts`
- Same replacement on the `clearCookie` call in the logout handler in `auth.controller.ts`

## Why

The auth cookie's `Secure` flag was hardcoded to `false` as a temporary measure — as the production build was not working. Now that prod is functional, the flag should be `true` in production so browsers only transmit the cookie over encrypted connections.

Injecting `NODE_ENV` at the Compose level solves this cleanly: a single code path reads the variable at runtime and behaves correctly in both environments without any duplication.

More broadly, `NODE_ENV` opens the door to meaningful dev/prod behavioural differences across the backend — for example, relaxing security checks or exposing additional endpoints in dev to simplify debugging, while keeping prod locked down. The cookie flag is the first concrete use of this pattern.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

## Production Tests

### Test 1 — Verify `NODE_ENV` is set in the prod container

**1. Start the production stack:**

```bash
make prod
```

> Make sure `DOMAIN` is set to `127.0.0.1` in the `.env` file

**2. Confirm `NODE_ENV` is set inside the backend container:**

```bash
docker compose -f compose.yaml -f compose.prod.yaml exec backend printenv NODE_ENV
```

> **Expected output:** `production`

---

### Test 2 — Verify the `Secure` flag is present for cookies

**1. Register a user to use in the following tests:**

```bash
curl -k -X POST https://127.0.0.1:8443/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email":"test@mail.com","username":"testuser","password":"testpass"}'
```

**2. Log in via the production endpoint and inspect the response headers:**

```bash
curl -k -c cookies.txt -X POST https://127.0.0.1:8443/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@mail.com","password":"testpass"}' \
  -v 2>&1 | grep -i "set-cookie"
```

> **Expected:** the `Set-Cookie` header includes `Secure`:
>
> ```text
> < set-cookie: access_token=...; HttpOnly; Secure; SameSite=Lax
> ```

---

### Test 3 — Verify the session works

**1. Verify the session is valid:**

```bash
curl -k -b cookies.txt -i https://127.0.0.1:8443/api/auth/me
```

> **Expected:** `200 OK` followed by the logged-in user's info.

**2. Stop the prod build:**

```bash
make down
```

---

## Development Tests

### Test 1 — Verify `NODE_ENV` is absent in dev

**1. set `DOMAIN` back to localhost in .env:**

```bash
sed -i "s|^DOMAIN=.*|DOMAIN=localhost|" .env
```

> **Note:** make sure you're at the project root when you run this command.

**2. Rebuild the stack in dev mode:**

```bash
make no-cache
```

**3. Start the dev stack:**

```bash
make up
```

**4. Try to print `NODE_ENV` in the dev container:**

```bash
docker compose -f compose.yaml -f compose.dev.yaml exec backend printenv NODE_ENV
```

> **Expected:** _(no output)_

---

### Test 2 — Verify the `Secure` flag is absent in dev

**1. Log in via the dev endpoint and inspect the response headers:**

```bash
curl -c cookies.txt -X POST http://localhost:1024/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@mail.com","password":"testpass"}' \
  -v 2>&1 | grep -i "set-cookie"
```

> **Expected:** `Secure` is **not** present in the `Set-Cookie` header — the cookie is still > issued and works normally over HTTP.

**Note:** if for some reason you did make nuke between tests, you'll have to register the user again in the DB! (make sure to use http, localhost and port 1024)

---

### Test 3 — Verify the session works

**1. Verify the session is valid:**

```bash
curl -k -b cookies.txt -i http://localhost:1024/api/auth/me 
```

> **Expected:** `200 OK` followed by the logged-in user's info.

## Cleanup

**1. Clean potential dangling images:**

```bash
make clean
```

**2. Delete cookies.txt file:**

```bash
rm cookies.txt
```
