### PR TITLE
[GAME][REMOTE] Preserve player identity across disconnect/reconnect

### DIFF
--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -40,28 +40,47 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private timersForfeit = new Map<string, NodeJS.Timeout>();
 
+  constructor(
+    private readonly gameService: GameService,
+    private readonly usersService: UsersService,
+  ) {}
+
   private getTimerKey(gameId: string, role: 'X' | 'O') {
     return `${gameId}:${role}`;
   }
 
   private clearTimerForfeit(gameId: string, role: 'X' | 'O') {
-    const timeKey = this.getTimerKey(gameId, role);
-    const timer = this.timersForfeit.get(timeKey);
+    const timerKey = this.getTimerKey(gameId, role);
+    const timer = this.timersForfeit.get(timerKey);
 
     if (timer) {
       clearTimeout(timer);
-      this.timersForfeit.delete(timeKey);
+      this.timersForfeit.delete(timerKey);
     }
   }
-  private startReconnectTime(gameId: string, role: 'X' | 'O') {
-    const timeKey = this.getTimerKey(gameId, role);
-    this.clearTimerForfeit(gameId, role); // clear the last one
-  }
 
-  constructor(
-    private readonly gameService: GameService,
-    private readonly usersService: UsersService,
-  ) {}
+  private startReconnectTimer(gameId: string, role: 'X' | 'O') {
+    const timerKey = this.getTimerKey(gameId, role);
+    this.clearTimerForfeit(gameId, role);
+
+    const timer = setTimeout(() => {
+      this.gameService
+        .finalizeReconnectTimeout(gameId, role)
+        .then((result) => {
+          if (result) {
+            this.server.to(gameId).emit('game_updated', result.game);
+          }
+        })
+        .catch((error) => {
+          console.error('Reconnect timeout error:', error);
+        })
+        .finally(() => {
+          this.timersForfeit.delete(timerKey);
+        });
+    }, 45000);
+
+    this.timersForfeit.set(timerKey, timer);
+  }
 
   handleConnection(client: Socket) {
     console.log(`Client connected : ${client.id}`);
@@ -72,7 +91,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const result = this.gameService.processPlayerDisconnection(client.id);
     if (!result) return;
     if (result.game.status === 'playing')
-      this.startReconnectTime(result.gameId, result.role);
+      this.startReconnectTimer(result.gameId, result.role);
     this.server.to(result.gameId).emit('game_updated', result.game);
   }
 

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -55,6 +55,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     if (timer) {
       clearTimeout(timer);
+      console.log(`[RECONNECT] cleared timer for ${role} in game ${gameId}`);
       this.timersForfeit.delete(timerKey);
     }
   }
@@ -62,6 +63,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private startReconnectTimer(gameId: string, role: 'X' | 'O') {
     const timerKey = this.getTimerKey(gameId, role);
     this.clearTimerForfeit(gameId, role);
+
+    console.log(`[RECONNECT] start grace period for ${role} in game ${gameId}`);
 
     const timer = setTimeout(() => {
       this.gameService

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -112,6 +112,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         userProfile,
       );
 
+      if (role === 'X' || role === 'O')
+        this.clearTimerForfeit(body.gameId, role);
+
       await client.join(body.gameId);
 
       console.log(`Client ${client.id} joined room ${body.gameId} as ${role}`);

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -39,7 +39,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   server!: Server;
 
   private timersForfeit = new Map<string, NodeJS.Timeout>();
-
+  private readonly RECONNECT_GRACE_MS = 20000;
   constructor(
     private readonly gameService: GameService,
     private readonly usersService: UsersService,
@@ -80,7 +80,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
         .finally(() => {
           this.timersForfeit.delete(timerKey);
         });
-    }, 45000);
+    }, this.RECONNECT_GRACE_MS);
 
     this.timersForfeit.set(timerKey, timer);
   }

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -44,7 +44,19 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return `${gameId}:${role}`;
   }
 
-  private startReconnectTime(gameId: string, role: 'X' | 'O') {}
+  private clearTimerForfeit(gameId: string, role: 'X' | 'O') {
+    const timeKey = this.getTimerKey(gameId, role);
+    const timer = this.timersForfeit.get(timeKey);
+
+    if (timer) {
+      clearTimeout(timer);
+      this.timersForfeit.delete(timeKey);
+    }
+  }
+  private startReconnectTime(gameId: string, role: 'X' | 'O') {
+    const timeKey = this.getTimerKey(gameId, role);
+    this.clearTimerForfeit(gameId, role); // clear the last one
+  }
 
   constructor(
     private readonly gameService: GameService,

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -91,9 +91,10 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @ConnectedSocket() client: AuthSocket,
   ) {
     try {
+      const userId = client.data.user.sub;
       const newGameState = await this.gameService.playMove(
         body.gameId,
-        client.id,
+        userId,
         body.r,
         body.c,
       );
@@ -112,6 +113,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @ConnectedSocket() client: AuthSocket,
   ) {
     try {
+      const userId = client.data.user.sub;
       const updateGame = this.gameService.requestReplay(body.gameId, client.id);
       this.server.to(body.gameId).emit('game_updated', updateGame);
       return updateGame;

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -40,6 +40,12 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private timersForfeit = new Map<string, NodeJS.Timeout>();
 
+  private getTimerKey(gameId: string, role: 'X' | 'O') {
+    return `${gameId}:${role}`;
+  }
+
+  private startReconnectTime(gameId: string, role: 'X' | 'O') {}
+
   constructor(
     private readonly gameService: GameService,
     private readonly usersService: UsersService,
@@ -53,9 +59,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     console.log(`Client disconnected : ${client.id}`);
     const result = this.gameService.processPlayerDisconnection(client.id);
     if (!result) return;
-    this.server.to(result.gameId).emit('game_updated', result.game);
     if (result.game.status === 'playing')
       this.startReconnectTime(result.gameId, result.role);
+    this.server.to(result.gameId).emit('game_updated', result.game);
   }
 
   @SubscribeMessage('join_game')

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -38,6 +38,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server!: Server;
 
+  private timersForfeit = new Map<string, NodeJS.Timeout>();
+
   constructor(
     private readonly gameService: GameService,
     private readonly usersService: UsersService,
@@ -47,12 +49,13 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     console.log(`Client connected : ${client.id}`);
   }
 
-  async handleDisconnect(client: Socket) {
+  handleDisconnect(client: Socket) {
     console.log(`Client disconnected : ${client.id}`);
-    const result = await this.gameService.processPlayerDisconnection(client.id);
-    if (result) {
-      this.server.to(result.gameId).emit('game_updated', result.game);
-    }
+    const result = this.gameService.processPlayerDisconnection(client.id);
+    if (!result) return;
+    this.server.to(result.gameId).emit('game_updated', result.game);
+    if (result.game.status === 'playing')
+      this.startReconnectTime(result.gameId, result.role);
   }
 
   @SubscribeMessage('join_game')
@@ -67,8 +70,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       const { game, role } = this.gameService.joinGame(
         body.gameId,
-        userId,
         client.id,
+        userId,
         userProfile,
       );
 
@@ -114,7 +117,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   ) {
     try {
       const userId = client.data.user.sub;
-      const updateGame = this.gameService.requestReplay(body.gameId, client.id);
+      const updateGame = this.gameService.requestReplay(body.gameId, userId);
       this.server.to(body.gameId).emit('game_updated', updateGame);
       return updateGame;
     } catch (error) {

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -67,6 +67,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
       const { game, role } = this.gameService.joinGame(
         body.gameId,
+        userId,
         client.id,
         userProfile,
       );

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -29,8 +29,8 @@ export function initGameState(): GameState {
     movesGameHistory: [],
 
     players: {
-      X: null,
-      O: null,
+      X: { ownerUserId: null, socketId: null },
+      O: { ownerUserId: null, socketId: null },
     },
 
     scores: {

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -174,22 +174,22 @@ export function applyMove(game: GameState, r: number, c: number): GameState {
  * - 2nd client: O (starts the game)
  * - others: spectator
  * @param game - The game state
- * @param clientId - The client identifier
+ * @param socketId - The client identifier
  * @return PlayerRole The assigned player role
  */
 export function assignPlayerRole(
   game: GameState,
-  clientId: string,
+  socketId: string,
 ): PlayerRole {
-  if (game.players.X === clientId) return 'X';
-  if (game.players.O === clientId) return 'O';
+  if (game.players.X === socketId) return 'X';
+  if (game.players.O === socketId) return 'O';
 
   if (!game.players.X) {
-    game.players.X = clientId;
+    game.players.X = socketId;
     return 'X';
   }
   if (!game.players.O) {
-    game.players.O = clientId;
+    game.players.O = socketId;
     game.status = 'playing';
     game.currentPlayer = 'X';
     game.lastMove = Date.now();
@@ -202,12 +202,12 @@ export function assignPlayerRole(
  * (GETTER)
  * Get the player role for a client
  * @param game - The game state
- * @param clientId - The client identifier
+ * @param socketId - The client identifier
  * @return PlayerRole The player role
  */
-export function getPlayerRole(game: GameState, clientId: string): PlayerRole {
-  if (game.players.X == clientId) return 'X';
-  if (game.players.O == clientId) return 'O';
+export function getPlayerRole(game: GameState, socketId: string): PlayerRole {
+  if (game.players.X == socketId) return 'X';
+  if (game.players.O == socketId) return 'O';
   return 'spectator';
 }
 

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -208,14 +208,33 @@ export function assignPlayerRole(
 
 /**
  * (GETTER)
- * Get the player role for a client
+ * Get the player role for a user
  * @param game - The game state
- * @param socketId - The client identifier
+ * @param userId - The user identifier
  * @return PlayerRole The player role
  */
-export function getPlayerRole(game: GameState, socketId: string): PlayerRole {
-  if (game.players.X == socketId) return 'X';
-  if (game.players.O == socketId) return 'O';
+export function getPlayerRoleByUserId(
+  game: GameState,
+  userId: number,
+): PlayerRole {
+  if (game.players.X.ownerUserId == userId) return 'X';
+  if (game.players.O.ownerUserId == userId) return 'O';
+  return 'spectator';
+}
+
+/**
+ * (GETTER)
+ * Get the player role for a connected/disconnected socket
+ * @param game - The game state
+ * @param socketId - The socket identifier
+ * @return PlayerRole The player role
+ */
+export function getPlayerRoleBySocketId(
+  game: GameState,
+  socketId: string,
+): PlayerRole {
+  if (game.players.X.socketId === socketId) return 'X';
+  if (game.players.O.socketId === socketId) return 'O';
   return 'spectator';
 }
 

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -179,17 +179,25 @@ export function applyMove(game: GameState, r: number, c: number): GameState {
  */
 export function assignPlayerRole(
   game: GameState,
+  userId: number,
   socketId: string,
 ): PlayerRole {
-  if (game.players.X === socketId) return 'X';
-  if (game.players.O === socketId) return 'O';
-
-  if (!game.players.X) {
-    game.players.X = socketId;
+  if (game.players.X.ownerUserId === userId) {
+    game.players.X.socketId = socketId;
     return 'X';
   }
-  if (!game.players.O) {
-    game.players.O = socketId;
+  if (game.players.O.ownerUserId === userId) {
+    game.players.O.socketId = socketId;
+    return 'O';
+  }
+  if (!game.players.X.ownerUserId) {
+    game.players.X.ownerUserId = userId;
+    game.players.X.socketId = socketId;
+    return 'X';
+  }
+  if (!game.players.O.ownerUserId) {
+    game.players.O.ownerUserId = userId;
+    game.players.O.socketId = socketId;
     game.status = 'playing';
     game.currentPlayer = 'X';
     game.lastMove = Date.now();

--- a/backend/src/modules/game/game.service.spec.ts
+++ b/backend/src/modules/game/game.service.spec.ts
@@ -17,7 +17,7 @@ describe('Game Engine Tests', () => {
     gameId = service.creatGame();
   });
 
-  const mockClientId = 'test-client-id';
+  const mockSocketId = 'test-client-id';
   afterEach(async () => {
     jest.clearAllTimers();
     jest.useRealTimers();
@@ -66,7 +66,7 @@ describe('Game Engine Tests', () => {
       }
 
       // 2. On joue et on log
-      service.playMove(gameId, mockClientId, r, c);
+      service.playMove(gameId, mockSocketId, r, c);
       logState(i + 1, r, c);
     }
 
@@ -88,7 +88,7 @@ describe('Game Engine Tests', () => {
 
     for (let i = 0; i < 50; i++) {
       const [r, c] = safeSequence[i % safeSequence.length];
-      service.playMove(gameId, mockClientId, r, c);
+      service.playMove(gameId, mockSocketId, r, c);
 
       if (service.getGameById(gameId).status === 'finished') {
         break;

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -60,21 +60,7 @@ export class GameService {
   ): { game: GameState; role: PlayerRole } {
     const game = this.getMutableGameById(gameId);
 
-    const isReconnectX =
-      game.players.X.ownerUserId === userId && game.players.X.socketId === null;
-
-    const isReconnectO =
-      game.players.O.ownerUserId === userId && game.players.O.socketId === null;
-
     const role = assignPlayerRole(game, userId, socketId);
-
-    if (
-      (isReconnectX || isReconnectO) &&
-      game.status === 'playing' &&
-      role === game.currentPlayer
-    ) {
-      game.lastMove = Date.now();
-    }
 
     if (user && (role === 'X' || role === 'O')) {
       game.playerProfiles[role] = user;

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -69,13 +69,13 @@ export class GameService {
     return { game, role };
   }
 
-  requestReplay(gameId: string, socketId: string): GameState {
+  requestReplay(gameId: string, userId: number): GameState {
     const game = this.getMutableGameById(gameId);
 
     if (game.status !== 'finished')
       throw new Error('Replay is only available after game end');
 
-    const role = getPlayerRoleByUserId(game, socketId);
+    const role = getPlayerRoleByUserId(game, userId);
 
     if (role !== 'X' && role !== 'O')
       throw new Error('Spectators cannot request replay');
@@ -138,37 +138,16 @@ export class GameService {
     return updatState;
   }
 
-  async processPlayerDisconnection(
+  processPlayerDisconnection(
     socketId: string,
-  ): Promise<{ gameId: string; game: GameState } | null> {
+  ): { gameId: string; role: 'X' | 'O'; game: GameState } | null {
     for (const [gameId, game] of this.activeGame.entries()) {
-      const wasX = game.players.X === socketId;
-      const wasO = game.players.O === socketId;
+      const role = getPlayerRoleBySocketId(game, socketId);
+      if (role === 'spectator') continue;
 
-      if (!wasX && !wasO) continue;
-
-      const role = wasX ? 'X' : 'O';
-      const other = role === 'X' ? 'O' : 'X';
-
-      game.players[role] = null;
-      game.playerProfiles[role] = null;
-
-      if (game.status === 'playing' && game.players[other]) {
-        game.status = 'finished';
-        game.winner = other;
-        game.endReason = 'forfeit';
-        game.scores[other] += 1;
-        game.toDisapear = -1;
-        await this.saveGameToDB(game);
-        game.replayVotes = { X: false, O: false };
-      }
-
-      if (game.status === 'waiting') {
-        game.winner = null;
-        game.endReason = null;
-      }
+      game.players[role].socketId = null;
       this.activeGame.set(gameId, game);
-      return { gameId, game };
+      return { gameId, role, game };
     }
 
     return null;

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -59,7 +59,6 @@ export class GameService {
     user?: PublicPlayerProfile,
   ): { game: GameState; role: PlayerRole } {
     const game = this.getMutableGameById(gameId);
-    const role = assignPlayerRole(game, userId, socketId);
 
     const isReconnectX =
       game.players.X.ownerUserId === userId && game.players.X.socketId === null;
@@ -114,7 +113,7 @@ export class GameService {
     // debug
     console.log('status =', game.status);
     console.log('players =', game.players);
-    console.log('socketId =', userId);
+    console.log('userId =', userId);
     console.log('role =', getPlayerRoleByUserId(game, userId));
     console.log('currentPlayer =', game.currentPlayer);
     //
@@ -204,6 +203,9 @@ export class GameService {
     if (game.players[other].ownerUserId === null) return null;
     if (game.players[other].socketId == null) return null;
     // if other player is not online maybe return state cancelled in the future
+
+    console.log(`[RECONNECT] finalize forfeit for ${role} in game ${gameId}`);
+
     game.status = 'finished';
     game.winner = other;
     game.endReason = 'forfeit';

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -53,11 +53,11 @@ export class GameService {
 
   joinGame(
     gameId: string,
-    clientId: string,
+    socketId: string,
     user?: PublicPlayerProfile,
   ): { game: GameState; role: PlayerRole } {
     const game = this.getMutableGameById(gameId);
-    const role = assignPlayerRole(game, clientId);
+    const role = assignPlayerRole(game, socketId);
 
     if (user && (role === 'X' || role === 'O')) {
       game.playerProfiles[role] = user;
@@ -67,13 +67,13 @@ export class GameService {
     return { game, role };
   }
 
-  requestReplay(gameId: string, clientId: string): GameState {
+  requestReplay(gameId: string, socketId: string): GameState {
     const game = this.getMutableGameById(gameId);
 
     if (game.status !== 'finished')
       throw new Error('Replay is only available after game end');
 
-    const role = getPlayerRole(game, clientId);
+    const role = getPlayerRole(game, socketId);
 
     if (role !== 'X' && role !== 'O')
       throw new Error('Spectators cannot request replay');
@@ -86,18 +86,23 @@ export class GameService {
     return game;
   }
 
-  async playMove(gameId: string, clientId: string, r: number, c: number): Promise<GameState> {
+  async playMove(
+    gameId: string,
+    socketId: string,
+    r: number,
+    c: number,
+  ): Promise<GameState> {
     const game = this.getMutableGameById(gameId);
     // debug
     console.log('status =', game.status);
     console.log('players =', game.players);
-    console.log('clientId =', clientId);
-    console.log('role =', getPlayerRole(game, clientId));
+    console.log('socketId =', socketId);
+    console.log('role =', getPlayerRole(game, socketId));
     console.log('currentPlayer =', game.currentPlayer);
     //
     if (game.status !== 'playing') throw new Error('Waiting for both players');
 
-    const role = getPlayerRole(game, clientId);
+    const role = getPlayerRole(game, socketId);
     if (role == 'spectator') throw new Error('Spectators cannot play');
     if (role !== game.currentPlayer) throw new Error('It is not your turn');
 
@@ -112,7 +117,7 @@ export class GameService {
       game.endReason = 'timeout';
       game.scores[timeOutWinner] += 1;
       game.toDisapear = -1;
-      await this.saveGameToDB(game)
+      await this.saveGameToDB(game);
       game.replayVotes = { X: false, O: false };
       this.activeGame.set(gameId, game);
       return game;
@@ -123,8 +128,8 @@ export class GameService {
 
     const updatState = applyMove(game, r, c);
 
-    if (updatState.status === 'finished'){
-      await this.saveGameToDB(updatState)
+    if (updatState.status === 'finished') {
+      await this.saveGameToDB(updatState);
     }
 
     this.activeGame.set(gameId, updatState);
@@ -132,11 +137,11 @@ export class GameService {
   }
 
   async processPlayerDisconnection(
-    clientId: string,
+    socketId: string,
   ): Promise<{ gameId: string; game: GameState } | null> {
     for (const [gameId, game] of this.activeGame.entries()) {
-      const wasX = game.players.X === clientId;
-      const wasO = game.players.O === clientId;
+      const wasX = game.players.X === socketId;
+      const wasO = game.players.O === socketId;
 
       if (!wasX && !wasO) continue;
 
@@ -152,7 +157,7 @@ export class GameService {
         game.endReason = 'forfeit';
         game.scores[other] += 1;
         game.toDisapear = -1;
-        await this.saveGameToDB(game)
+        await this.saveGameToDB(game);
         game.replayVotes = { X: false, O: false };
       }
 
@@ -167,20 +172,24 @@ export class GameService {
     return null;
   }
 
-private async saveGameToDB(game: GameState) {
-  if (!game.playerProfiles.X || !game.playerProfiles.O) return
+  private async saveGameToDB(game: GameState) {
+    if (!game.playerProfiles.X || !game.playerProfiles.O) return;
 
-  const data = {
-  player1Id: game.playerProfiles.X.id,
-  player2Id: game.playerProfiles.O.id,
-  scoresP1: game.scores.X,
-  scoresP2: game.scores.O,
-  winnerId: (game.winner === 'X') ? game.playerProfiles.X?.id : (game.winner === 'O') ? game.playerProfiles.O?.id : undefined,
-  endReason: game.endReason
+    const data = {
+      player1Id: game.playerProfiles.X.id,
+      player2Id: game.playerProfiles.O.id,
+      scoresP1: game.scores.X,
+      scoresP2: game.scores.O,
+      winnerId:
+        game.winner === 'X'
+          ? game.playerProfiles.X?.id
+          : game.winner === 'O'
+            ? game.playerProfiles.O?.id
+            : undefined,
+      endReason: game.endReason,
+    };
+
+    await this.matchService.recordMatch(data, game.movesGameHistory);
+    console.log('Save to DB successful');
   }
-
-  await this.matchService.recordMatch(data, game.movesGameHistory)
-  console.log("Save to DB successful")
-}
-
 }

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -54,10 +54,11 @@ export class GameService {
   joinGame(
     gameId: string,
     socketId: string,
+    userId: number,
     user?: PublicPlayerProfile,
   ): { game: GameState; role: PlayerRole } {
     const game = this.getMutableGameById(gameId);
-    const role = assignPlayerRole(game, socketId);
+    const role = assignPlayerRole(game, userId, socketId);
 
     if (user && (role === 'X' || role === 'O')) {
       game.playerProfiles[role] = user;

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -61,6 +61,22 @@ export class GameService {
     const game = this.getMutableGameById(gameId);
     const role = assignPlayerRole(game, userId, socketId);
 
+    const isReconnectX =
+      game.players.X.ownerUserId === userId && game.players.X.socketId === null;
+
+    const isReconnectO =
+      game.players.O.ownerUserId === userId && game.players.O.socketId === null;
+
+    const role = assignPlayerRole(game, userId, socketId);
+
+    if (
+      (isReconnectX || isReconnectO) &&
+      game.status === 'playing' &&
+      role === game.currentPlayer
+    ) {
+      game.lastMove = Date.now();
+    }
+
     if (user && (role === 'X' || role === 'O')) {
       game.playerProfiles[role] = user;
     }

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -6,7 +6,8 @@ import {
   initGameState,
   validateToMove,
   applyMove,
-  getPlayerRole,
+  getPlayerRoleByUserId,
+  getPlayerRoleBySocketId,
   assignPlayerRole,
   resetBoardForReplay,
 } from './game.logic';
@@ -74,7 +75,7 @@ export class GameService {
     if (game.status !== 'finished')
       throw new Error('Replay is only available after game end');
 
-    const role = getPlayerRole(game, socketId);
+    const role = getPlayerRoleByUserId(game, socketId);
 
     if (role !== 'X' && role !== 'O')
       throw new Error('Spectators cannot request replay');
@@ -89,7 +90,7 @@ export class GameService {
 
   async playMove(
     gameId: string,
-    socketId: string,
+    userId: number,
     r: number,
     c: number,
   ): Promise<GameState> {
@@ -97,13 +98,13 @@ export class GameService {
     // debug
     console.log('status =', game.status);
     console.log('players =', game.players);
-    console.log('socketId =', socketId);
-    console.log('role =', getPlayerRole(game, socketId));
+    console.log('socketId =', userId);
+    console.log('role =', getPlayerRoleByUserId(game, userId));
     console.log('currentPlayer =', game.currentPlayer);
     //
     if (game.status !== 'playing') throw new Error('Waiting for both players');
 
-    const role = getPlayerRole(game, socketId);
+    const role = getPlayerRoleByUserId(game, userId);
     if (role == 'spectator') throw new Error('Spectators cannot play');
     if (role !== game.currentPlayer) throw new Error('It is not your turn');
 

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -173,4 +173,30 @@ export class GameService {
     await this.matchService.recordMatch(data, game.movesGameHistory);
     console.log('Save to DB successful');
   }
+
+  async finalizeReconnectTimeout(
+    gameId: string,
+    role: 'X' | 'O',
+  ): Promise<{ gameId: string; game: GameState } | null> {
+    const game = this.getMutableGameById(gameId);
+
+    const seat = game.players[role];
+    if (seat.socketId != null) return null;
+    if (game.status !== 'playing') return null;
+
+    const other = role === 'X' ? 'O' : 'X';
+    if (game.players[other].ownerUserId === null) return null;
+    if (game.players[other].socketId == null) return null;
+    // if other player is not online maybe return state cancelled in the future
+    game.status = 'finished';
+    game.winner = other;
+    game.endReason = 'forfeit';
+    game.scores[other] += 1;
+    game.toDisapear = -1;
+    game.replayVotes = { X: false, O: false };
+
+    await this.saveGameToDB(game);
+    this.activeGame.set(gameId, game);
+    return { gameId, game };
+  }
 }

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -37,8 +37,8 @@ export interface PlayerSeat {
 
 // to stock socketId of client x and client o
 export interface PlayersInGame {
-  X: string | null;
-  O: string | null;
+  X: PlayerSeat;
+  O: PlayerSeat;
 }
 
 export interface ReplayState {

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -30,6 +30,11 @@ export interface Move extends BoardPosition {
   player: PlayerSymbol;
 }
 
+export interface PlayerSeat {
+  ownerUserId: number | null;
+  socketId: string | null;
+}
+
 // to stock socketId of client x and client o
 export interface PlayersInGame {
   X: string | null;

--- a/frontend/src/type/game.types.ts
+++ b/frontend/src/type/game.types.ts
@@ -30,10 +30,15 @@ export interface Move extends BoardPosition {
   player: PlayerSymbol;
 }
 
+export interface PlayerSeat {
+  ownerUserId: number | null;
+  socketId: string | null;
+}
+
 // to stock socketId of client x and client o
 export interface PlayersInGame {
-  X: string | null;
-  O: string | null;
+  X: PlayerSeat;
+  O: PlayerSeat;
 }
 
 export interface ReplayState {


### PR DESCRIPTION
## # Summary
This PR stops game seat ownership from depending on `socket.id` alone. 
Seats are now owned by **authenticated users**, allowing a player to refresh or reconnect and recover their `X` or `O` role instead of losing ownership due to a new socket connection.

---

## # Validation Note
> [!IMPORTANT]
> **Manual validation only:** Automated local test execution was not available from this environment. This description is based on the logic inspection of the `feature/game-reconnect` branch files.

---

## # Why
On the current `dev` branch, seat ownership is tied to raw Socket.IO connection IDs. A page refresh makes the user look like a "new" player, breaking the game state.
This branch separates **stable ownership** (User ID) from **live presence** (Socket ID).

---

## # What changed

### Backend
- **Stable Seats:** Replaces raw socket strings with a `PlayerSeat { ownerUserId, socketId }` structure.
- **Seat Recovery:** `assignPlayerRole()` now checks if the `userId` already owns a seat before creating a new one.
- **Persistence:** Disconnect no longer deletes the player; it sets `socketId = null` and triggers a grace period.
- **Move Timer Reset:** If the reconnecting player is the `currentPlayer`, `lastMove` is reset to prevent immediate timeout after the loading screen.
- **Grace Period:** Added a reconnect timer in the Gateway. If it expires while the opponent is still online, the game ends by `forfeit`.

### Frontend
- **Types:** Updated `PlayerSeat` to match the backend.
- **Logic:** Minimal changes; state resync still relies on the existing `joined_as` + `game_updated` flow.

---

## # Key Files to Review
1. `backend/src/modules/game/game.service.ts` (Core logic & forfeit)
2. `backend/src/modules/game/game.gateway.ts` (Timers & socket management)
3. `backend/src/modules/game/game.logic.ts` (Seat assignment)
4. `backend/src/modules/game/game.types.ts` & `frontend/src/type/game.types.ts`

---

## # Diagrams

### Disconnect -> Reconnect / Forfeit Flow
```mermaid
sequenceDiagram
    participant X as Player X
    participant O as Opponent
    participant G as Gateway
    participant S as Service
    participant T as Reconnect timer

    X-xG: disconnect
    G->>S: processPlayerDisconnection(socketId)
    S-->>G: socketId = null
    G->>T: start grace timer

    alt reconnect before timer expires
        X->>G: join_game(gameId)
        G->>S: joinGame(gameId, newSocketId, sameUserId)
        S-->>G: restore X
        G->>T: clear timer
        G-->>X: joined_as X
        G-->>All: game_updated
    else no reconnect
        T-->>G: timer expires
        G->>S: finalizeReconnectTimeout(gameId, X)
        S-->>G: winner = O, endReason = forfeit
        G-->>All: game_updated
    end
```

---

## # Code Highlights

**Stable seat structure:**
```typescript
export interface PlayerSeat {
  ownerUserId: number | null;
  socketId: string | null;
}
```

**Reset move timeout on active-player reconnect:**
```typescript
if ((isReconnectX || isReconnectO) && game.status === 'playing' && role === game.currentPlayer) {
  game.lastMove = Date.now();
}
```

---

## # How to Test (Manual)
1. **Refresh Recovery:** Start a game between two logged-in users. Refresh the page.
   - *Expected:* You should automatically rejoin as the same role (X or O).
2. **Move Timeout Reset:** Make it Player A's turn. Refresh Player A.
   - *Expected:* Player A returns, and the turn timer effectively restarts from the moment of reconnection.
3. **Forfeit:** Disconnect Player A and wait past the grace period while Player B stays online.
   - *Expected:* Game ends, Player B wins by `forfeit`.
4. **Resync:** Play 5 moves, then refresh.
   - *Expected:* The board state is perfectly restored.

---

## # Known Limitations & Risks
- **Auth Only:** Reconnect only works for authenticated users (required for stable `userId`).
- **Both Offline:** If both players disconnect, the game currently does not auto-resolve.
- **UI:** No specific "Player Disconnected" overlay has been added to the frontend yet.

---

## # Reviewer Checklist
- [ ] Seats are stable by `ownerUserId`.
- [ ] Disconnect only clears `socketId`, does not wipe the seat.
- [ ] Reconnect clears the pending forfeit timer.
- [ ] Move timeout resets upon active player return.
- [ ] Forfeit finalizes correctly if the opponent is online.


Close #179 