### PR TITLE
[INFRA] - Auto-detect LAN IP during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,14 @@ COMPOSE_PROD		= compose.prod.yaml
 # ══════════════════════════════════════════════════════
 ##@ START STACK
 
-up: setup ## Build and run all containers [DEV]
+up: _check-required-files ## Build and run all containers [DEV]
 	@echo "$(GREEN)Running in Dev Mode$(RES)"
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) up -d
 
-build: setup ## Build all containers [DEV]
+build: _check-required-files ## Build all containers [DEV]
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) build
 
-no-cache: setup ## Rebuild all containers in no-cache mode [DEV]
+no-cache: _check-required-files ## Rebuild all containers in no-cache mode [DEV]
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) build --no-cache
 
 re: down build up ## Stop, rebuild, and restart the full stack [DEV]

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -36,7 +36,16 @@ REQUIRED_FILES = \
 
 # ══════════════════════════════════════════════════════
 
-setup: # Checks required files; prompt for default setup if any are missing
+setup: # Prompts user to run default setup
+	@printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
+	case "$$ans" in \
+		y|Y|yes|Yes|YES) \
+			$(MAKE) --no-print-directory _setup-apply ;; \
+		*) \
+			exit 0 ;; \
+	esac
+
+_check-required-files: # Checks required files exist
 	@missing=0; \
 	for f in $(REQUIRED_FILES); do \
 		if [ ! -f "$$f" ]; then \
@@ -46,14 +55,10 @@ setup: # Checks required files; prompt for default setup if any are missing
 	done; \
 	if [ "$$missing" -eq 0 ]; then \
 		echo "$(GREEN)✓ All required files present$(RES)"; \
+	else \
+		$(MAKE) --no-print-directory _setup-apply ; \
 	fi; \
-	printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
-	case "$$ans" in \
-		y|Y|yes|Yes|YES) \
-			$(MAKE) --no-print-directory _setup-apply ;; \
-		*) \
-			exit 0 ;; \
-	esac
+	
 
 _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
   	# ── Overwrite .env File ─────────────────────────────────────────────────────
@@ -91,4 +96,4 @@ _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
 	esac
 	
 
-.PHONY: setup _setup-apply
+.PHONY: setup _setup-apply _check-required-files

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -37,7 +37,8 @@ REQUIRED_FILES = \
 # ══════════════════════════════════════════════════════
 
 setup: # Prompts user to run default setup
-	@printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
+	@echo "$(ORANGE)Building default setup will overwrite all setup files.$(RES)"; \
+	printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
 	case "$$ans" in \
 		y|Y|yes|Yes|YES) \
 			$(MAKE) --no-print-directory _setup-apply ;; \
@@ -56,6 +57,7 @@ _check-required-files: # Checks required files exist
 	if [ "$$missing" -eq 0 ]; then \
 		echo "$(GREEN)✓ All required files present$(RES)"; \
 	else \
+		echo "$(CYAN)Missing files detected. Rebuilding defaults.$(RES)"; \
 		$(MAKE) --no-print-directory _setup-apply ; \
 	fi; \
 	

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -46,18 +46,17 @@ setup: # Checks required files; prompt for default setup if any are missing
 	done; \
 	if [ "$$missing" -eq 0 ]; then \
 		echo "$(GREEN)✓ All required files present$(RES)"; \
-		exit 0; \
 	fi; \
 	printf "$(CYAN)Build default setup?$(RES) [y/N] "; read ans; \
 	case "$$ans" in \
 		y|Y|yes|Yes|YES) \
 			$(MAKE) --no-print-directory _setup-apply ;; \
 		*) \
-			echo "$(RED)Aborted. Fix missing files manually by running $(GOLD)\`make setup\`$(RES)"; \
-			exit 1 ;; \
+			exit 0 ;; \
 	esac
 
 _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
+  	# ── Overwrite .env File ─────────────────────────────────────────────────────
 	@{ \
 		for pair in $(DEV_ONLY_ENV_VARS); do \
 			echo "$$pair"; \
@@ -65,12 +64,14 @@ _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
 		grep -v '^\s*#' .env.example; \
 	} > .env
 	@echo "$(GREEN)✓ .env created (dev-only vars prepended, comments stripped)$(RES)"
+  	# ── Replace values with Defaults ─────────────────────────────────────────
 	@for pair in $(DEFAULT_ENV_VARS); do \
 		key=$$(echo "$$pair" | cut -d= -f1); \
 		val=$$(echo "$$pair" | cut -d= -f2-); \
 		sed -i "s|^$${key}=.*|$${key}=$${val}|" .env; \
 	done
 	@echo "$(GREEN)✓ Default values applied to .env$(RES)"
+  	# ── Create Secret Files ──────────────────────────────────────────────────
 	@mkdir -p $(SECRETS_DIR)
 	@for pair in $(DEFAULT_SECRETS); do \
 		file=$$(echo "$$pair" | cut -d= -f1); \
@@ -78,5 +79,16 @@ _setup-apply: # Wipe and recreate .env and all secrets with hardcoded defaults
 		echo "$$content" > $(SECRETS_DIR)$$file; \
 		echo "$(GREEN)✓ $(SECRETS_DIR)$$file created$(RES)"; \
 	done
+  	# ── Prompt for auto LAN setup ────────────────────────────────────────────
+	@printf "$(CYAN)Setup with local LAN?$(RES) [y/N] "; read ans; \
+	case "$$ans" in \
+		y|Y|yes|Yes|YES) \
+			ip=$$(ip route get 1.1.1.1 | awk '{for(i=1;i<=NF;i++) if($$i=="src") print $$(i+1)}'); \
+			sed -i "s|^DOMAIN=.*|DOMAIN=$$ip|" .env; \
+			echo "Using custom DOMAIN: '$(GOLD)$$ip$(RES)'";; \
+		*) \
+			echo "Using default DOMAIN: '$(GOLD)127.0.0.1$(RES)'";; \
+	esac
+	
 
 .PHONY: setup _setup-apply


### PR DESCRIPTION
# [INFRA] - Auto-detect LAN IP during setup

Closes #197 

## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

### **make/setup.mk:**

- Added a "Setup with local LAN?" prompt at the end of `_setup-apply`
- On yes: detects the outbound LAN IP via `ip route get 1.1.1.1 | awk` and writes it to `DOMAIN` in `.env`
- On no: keeps the default `DOMAIN=127.0.0.1`
- Extracted apply logic from `setup` into `_setup-apply` — `setup` now prompts "Build default setup?" and delegates to `_setup-apply` on confirmation
- Added `_check-required-files` target — auto-runs `_setup-apply` directly (no prompt) when any required file is missing
- Added `_setup-apply` and `_check-required-files` to `.PHONY`

### **Makefile:**

- Changed `up`, `build`, and `no-cache` to depend on `_check-required-files` instead of `setup`

## Why

Previously, running a build target with missing files would prompt "Build default setup?" before doing anything. Now `_check-required-files` applies defaults silently — files are required for the stack to run, so there is nothing to decide. The LAN prompt at the end of `_setup-apply` remains the one meaningful choice.

`make setup` is now a standalone dev tool: running it directly always prompts and re-applies defaults, making it easy to reconfigure `DOMAIN` without touching `.env` by hand.

`ip route get 1.1.1.1 | awk` is used over `hostname -i` to reliably target the correct outbound interface, avoiding issues with Docker bridge IPs, multiple interfaces, and IPv6.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

## Development Tests

### Dev Test 1 — LAN setup sets the correct IP

**1. Wipe existing setup and run fresh:**

```bash
make nuke
make setup
```

> Enter `y` when prompted "Setup with local LAN?". Note the IP printed.

**2. Verify `DOMAIN` in `.env` matches the printed IP:**

```bash
grep DOMAIN .env
```

**3. *(Optional — requires a second device on the same network)* Start the stack and access the app from another device:**

```bash
make up
```

> Open a browser on the other device and navigate to `http://<IP>:1024` (dev) or `https://<IP>:8443` (prod), using the IP from `.env`.

---

### Dev Test 2 — Declining LAN keeps default

**1. Run setup and decline LAN:**

```bash
make setup
```

> Enter `n` when prompted "Setup with local LAN?".

**2. Verify `DOMAIN` is set to the default:**

```bash
grep DOMAIN .env
```

> **Expected:** `DOMAIN=127.0.0.1`

---

### Dev Test 3 — make up auto-runs setup when files are missing

**1. Remove a couple of required files to simulate a fresh clone:**

```bash
rm .env secrets/backend_pw.txt
```

**2. Run the stack:**

```bash
make up
```

> **Expected:** `_setup-apply` runs automatically — no "Build default setup?" prompt. Missing files are listed, the LAN prompt appears, then the stack builds.

## Note
You can now use `make setup` as an easy and fast way to switch the IP in the `.env`!
Simply run `make setup` and answer `yes` or `no` to quickly switch between your local LAN IP and the default `127.0.0.1`