### PR TITLE
[INFRA] - Improve make nuke confirmation and structure

### DIFF
--- a/make/clean.mk
+++ b/make/clean.mk
@@ -36,6 +36,14 @@ nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + sec
 	esac
 	
 _nuke-apply: # Runs a full wipe
+	@printf "$(CYAN)Remove postgres:$(POSTGRES_VERSION)? Skip if rebuilding soon$(RES) [y/N] "; read ans; \
+	case "$$ans" in \
+		y|Y|yes|Yes|YES) \
+			echo "$(CYAN)<Removing postgres:$(POSTGRES_VERSION)>$(RES)"; \
+			docker image rm postgres:$(POSTGRES_VERSION) 2>/dev/null || true ;; \
+		*) ;; \
+	esac
+
 	@echo ""
 	@echo "$(CYAN)<Stopping stack and removing containers + volumes>$(RES)"
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) down --volumes --remove-orphans
@@ -46,9 +54,6 @@ _nuke-apply: # Runs a full wipe
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) down --rmi local 2>/dev/null || true
 	@docker compose -p prod -f $(COMPOSE_FILE) -f $(COMPOSE_PROD) down --rmi local 2>/dev/null || true
 	@docker image prune -f
- 
-	@echo "$(CYAN)<Removing postgres:$(POSTGRES_VERSION)>$(RES)"
-	@docker image rm postgres:$(POSTGRES_VERSION) 2>/dev/null || true
  
 	@echo "$(CYAN)<Clearing all build cache>$(RES)"
 	@docker buildx prune -f

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -36,6 +36,7 @@ nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + sec
 	esac
 	
 _nuke-apply: # Runs a full wipe
+  	# ── Prompt for Postgres Image Removal ────────────────────────────────────
 	@printf "$(CYAN)Remove postgres:$(POSTGRES_VERSION)? Skip if rebuilding soon$(RES) [y/N] "; read ans; \
 	case "$$ans" in \
 		y|Y|yes|Yes|YES) \
@@ -44,20 +45,24 @@ _nuke-apply: # Runs a full wipe
 		*) ;; \
 	esac
 
+  	# ── Stop Stack, Remove Containers + Volumes ──────────────────────────────
 	@echo ""
 	@echo "$(CYAN)<Stopping stack and removing containers + volumes>$(RES)"
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) down --volumes --remove-orphans
 	@docker compose -p prod -f $(COMPOSE_FILE) -f $(COMPOSE_PROD) down --volumes --remove-orphans
 	@docker volume prune -f
- 
+
+  	# ── Remove dev & prod Images ─────────────────────────────────────────────
 	@echo "$(CYAN)<Removing images built by this stack>$(RES)"
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) down --rmi local 2>/dev/null || true
 	@docker compose -p prod -f $(COMPOSE_FILE) -f $(COMPOSE_PROD) down --rmi local 2>/dev/null || true
 	@docker image prune -f
- 
+
+  	# ── Clear Build Cache ────────────────────────────────────────────────────
 	@echo "$(CYAN)<Clearing all build cache>$(RES)"
 	@docker buildx prune -f
- 
+
+  	# ── Remove Setup & Secret Files ──────────────────────────────────────────
 	@echo "$(CYAN)<Removing .env and secret files>$(RES)"
 	@rm -f $(REQUIRED_FILES)
 	@echo ""

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -2,6 +2,9 @@
 #                  CLEAN TARGETS
 # ══════════════════════════════════════════════════════
 
+# Fallback if .env is missing or does not define POSTGRES_VERSION (mirrors setup.mk default)
+POSTGRES_VERSION ?= 18-alpine
+
 ##@ CLEAN
 
 clean: ## Remove dangling images, stopped containers, unused networks + build cache [BOTH]

--- a/make/clean.mk
+++ b/make/clean.mk
@@ -26,8 +26,16 @@ nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + sec
 	@echo "   - The .env file"
 	@echo "   - All secret files"
 	@echo "   - All Postgres data"
-	@printf "$(CYAN)Continue? [y/N] $(RES)" && read ans && [ "$$ans" = "y" ] || (echo "$(RED)   Aborted$(RES)" && exit 1)
- 
+# 	@printf "$(CYAN)Continue? [y/N] $(RES)" && read ans && [ "$$ans" = "y" ] || (echo "$(RED)   Aborted$(RES)" && exit 1)
+	@printf "$(CYAN)Continue? [y/N] $(RES)"; read ans; \
+	case "$$ans" in \
+		y|Y|yes|Yes|YES) \
+			$(MAKE) --no-print-directory _nuke-apply ;; \
+		*) \
+			exit 0 ;; \
+	esac
+	
+_nuke-apply: # Runs a full wipe
 	@echo ""
 	@echo "$(CYAN)<Stopping stack and removing containers + volumes>$(RES)"
 	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) down --volumes --remove-orphans
@@ -53,4 +61,4 @@ nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + sec
 	@echo ""
 	@docker system df
 	
-.PHONY: clean nuke
+.PHONY: clean nuke _nuke-apply

--- a/make/setup.mk
+++ b/make/setup.mk
@@ -6,6 +6,7 @@ SECRETS_DIR = secrets/
 
 # ── Add new .env defaults here ────────────────────────────────────────────────
 # Format: KEY=value   (replaces the KEY=... line after copying .env.example)
+# Note: if POSTGRES_VERSION is changed, please update it in `make/clean.mk` too
 DEFAULT_ENV_VARS = \
 	DOMAIN=127.0.0.1 \
 	POSTGRES_VERSION=18-alpine \


### PR DESCRIPTION
# [INFRA] - Improve make nuke confirmation and structure

Closes #202 

## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

**Makefile:**

- Split `nuke` into `nuke` (confirmation prompt) and `_nuke-apply` (destructive steps), mirroring the `setup` / `_setup-apply` pattern
- Replaced one-liner confirmation with a `case`-based prompt — accepts `y`, `Y`, `yes`, `Yes`, `YES`
- Added `_nuke-apply` to `.PHONY`
- Added prompt to delete Postgres image (To allow devs to skip if they plan a rebuild)

## Why

The previous confirmation prompt only matched a lowercase `y`, silently aborting on any other common affirmative. Splitting the prompt from the action also makes the recipe consistent with how `make setup` is structured across the Makefile.

Previously make nuke would remove postgres image and each rebuild would pull the image again. This was intended behaviour, however for practicality I have added an extra prompt to make nuke to skip removing Postgres so the rebuild should take less time!

## Testing

- [x] Docker build successful
- [x] Integration tested manually

## Development Tests

### Test 1 — Confirmation accepts common affirmatives

**1. Run nuke and confirm Postgres removal:**

```bash
make nuke
```

> Enter `Y` or `yes` when prompted. Verify the wipe proceeds normally.

**2. Run nuke and decline:**

```bash
make nuke
```

> Enter `n` or press Enter. Verify the command exits cleanly without wiping anything.

---

### Test 2 — Rebuild and nuke skipping Postgres Removal

**1. Rebuild the dev stack:**
```bash
make up
```
> You should see postgres image being pulled from Dockerhub

**2. Run nuke and decline Postgres removal:**

```bash
make nuke
```
> When prompted about Postgres, simply tap 'enter' to skip its removal!

**3. Check Postgres image is still present:**

```bash
docker image ls
```

**You should see:**

```bash
IMAGE                ID             DISK USAGE   CONTENT SIZE   EXTRA
postgres:18-alpine   54451ecb8ab3        409MB          115MB 
```

**4. Verify both stacks rebuild cleanly from scratch:**

```bash
make up
make prod
```
> **Note:** this time Postgres image should not be pulled and the build should start immediately!