### PR TITLE
feat(game): add live games and improve remote game UX

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,9 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -e
             cd /app/Ft_transcendence
             git fetch origin
             git checkout dev
             git reset --hard origin/dev
-            make prod
+            docker compose -p prod -f compose.yaml -f compose.prod.yaml up -d --build backend frontend

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -65,12 +65,14 @@ export class AuthController {
 				secure: process.env.NODE_ENV === 'production',
 				sameSite: 'lax',
 				maxAge: 5 * 60 * 1000,
+				path: '/',
 			});
 
 			res.clearCookie('access_token', {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === 'production',
 				sameSite: 'lax',
+				path: '/',
 			});
 
 			return {
@@ -84,12 +86,14 @@ export class AuthController {
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 			maxAge: 60 * 60 * 1000,
+			path: '/',
 		});
 
 		res.clearCookie('2fa_pending', {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
+			path: '/',
 		});
 
 		return {
@@ -110,12 +114,14 @@ export class AuthController {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
+			path: '/',
 		});
 
 		res.clearCookie('2fa_pending', {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
+			path: '/',
 		});
 
 		return { message: 'Logout successful' };
@@ -220,12 +226,14 @@ export class AuthController {
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 			maxAge: 60 * 60 * 1000,
+			path: '/',
 		});
 
 		res.clearCookie('2fa_pending', {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
+			path: '/',
 		});
 
 		return {

--- a/backend/src/auth/oauth.controller.ts
+++ b/backend/src/auth/oauth.controller.ts
@@ -54,6 +54,7 @@ export class OAuthController {
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 			maxAge: 5 * 60 * 1000,
+			path: '/',
 		});
 
 		const params = new URLSearchParams({

--- a/backend/src/modules/game/game.controller.ts
+++ b/backend/src/modules/game/game.controller.ts
@@ -18,4 +18,8 @@ export class GameController {
   getFinishedGameHistory(@Param('id') gameId: string) {
     return this.gameService.getFinishedGamesHistory(gameId);
   }
+  @Get('liveGames')
+  getLiveGames() {
+    return this.gameService.getLiveGames();
+  }
 }

--- a/backend/src/modules/game/game.controller.ts
+++ b/backend/src/modules/game/game.controller.ts
@@ -10,16 +10,19 @@ export class GameController {
     const gameId = this.gameService.creatGame();
     return { gameId };
   }
+
+  @Get('liveGames')
+  getLiveGames() {
+    return this.gameService.getLiveGames();
+  }
+
   @Get(':id')
   getGame(@Param('id') gameId: string) {
     return this.gameService.getGameById(gameId);
   }
+
   @Get(':id/history')
   getFinishedGameHistory(@Param('id') gameId: string) {
     return this.gameService.getFinishedGamesHistory(gameId);
-  }
-  @Get('liveGames')
-  getLiveGames() {
-    return this.gameService.getLiveGames();
   }
 }

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -276,6 +276,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() body: { gameId: string },
     @ConnectedSocket() client: AuthSocket,
   ) {
+    console.log('LEAVE_GAME received from:', client.id);
+    console.log('gameId:', body.gameId);
     try {
       client.to(body.gameId).emit('opponent_left', {
         message: 'Your opponent left - no replay',

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -15,6 +15,8 @@ import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UseGuards } from '@nestjs/common';
 import { UsersService } from 'src/users/users.service';
 import type { AuthSocket } from 'src/auth/jwt-auth.guard';
+import { subscribe } from 'node:diagnostics_channel';
+import { error } from 'node:console';
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
 const parts = rawOrigins.split(',');
@@ -33,7 +35,7 @@ const allowedOrigins = trimmedOrigins.filter(function (origin) {
     credentials: true,
   },
 })
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard) // TODO: verify if can delete (is no necessary bcz CALLED FOR APP)
 export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server!: Server;
@@ -262,6 +264,24 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       const updateGame = this.gameService.requestReplay(body.gameId, userId);
       this.emitGameUpdate(body.gameId, updateGame);
       return updateGame;
+    } catch (error) {
+      client.emit('game_error', {
+        message: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
+  @SubscribeMessage('leave_game')
+  async handleLeaveGame(
+    @MessageBody() body: { gameId: string },
+    @ConnectedSocket() client: AuthSocket,
+  ) {
+    try {
+      client.to(body.gameId).emit('opponent_left', {
+        message: 'Your opponent left - no replay',
+      });
+
+      await client.leave(body.gameId);
     } catch (error) {
       client.emit('game_error', {
         message: error instanceof Error ? error.message : 'Unknown error',

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -10,7 +10,7 @@ import {
 import { GameService, TURN_TIMEOUT_MS } from './game.service';
 import { PlayMoveDto } from './dto/play-move.dto';
 import { Server, Socket } from 'socket.io';
-import { GameState } from './game.types';
+import { GameState, PlayerRole } from './game.types';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UseGuards } from '@nestjs/common';
 import { UsersService } from 'src/users/users.service';
@@ -279,10 +279,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     console.log('LEAVE_GAME received from:', client.id);
     console.log('gameId:', body.gameId);
     try {
-      client.to(body.gameId).emit('opponent_left', {
-        message: 'Your opponent left - no replay',
-      });
-
+      const userId = client.data.user.sub;
+      const game = this.gameService.setPlayerLeft(body.gameId, userId);
+      this.emitGameUpdate(body.gameId, game);
       await client.leave(body.gameId);
     } catch (error) {
       client.emit('game_error', {

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -184,7 +184,8 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     if (result) {
       if (result.game.status === 'playing')
         this.startReconnectTimer(result.gameId, result.role);
-
+      if (result?.game.status === 'finished')
+        result.game.playerLeft = result.role;
       this.emitGameUpdate(result.gameId, result.game);
       this.cleanupFinishedGameIfEmpty(result.gameId);
       return;

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -27,6 +27,7 @@ export function initGameState(): GameState {
     lastMove: Date.now(),
     movesGameHistory: [],
     spectatCnt: 0,
+    playerLeft: null,
 
     players: {
       X: {

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -233,12 +233,23 @@ export class GameService {
   }
 
   getLiveGames() {
-    const waiting: GameState[] = [];
-    const playing: GameState[] = [];
-    const allGames = [...this.activeGame.values()];
-    for (const game of allGames) {
-      if (game.status === 'waiting') waiting.push(game);
-      else if (game.status === 'playing') playing.push(game);
+    const waiting: { gameId: string; playerX: PublicPlayerProfile | null }[] =
+      [];
+    const playing: {
+      gameId: string;
+      playerX: PublicPlayerProfile | null;
+      playerO: PublicPlayerProfile | null;
+    }[] = [];
+    const allGames = [...this.activeGame.entries()];
+    for (const [gameId, game] of allGames) {
+      if (game.status === 'waiting')
+        waiting.push({ gameId, playerX: game.playerProfiles.X });
+      else if (game.status === 'playing')
+        playing.push({
+          gameId,
+          playerX: game.playerProfiles.X,
+          playerO: game.playerProfiles.O,
+        });
     }
     return { waiting, playing };
   }

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -223,4 +223,12 @@ export class GameService {
     this.activeGame.set(gameId, game);
     return game;
   }
+
+  setPlayerLeft(gameId: string, userId: number): GameState {
+    const game = this.getMutableGameById(gameId);
+    const role = getPlayerRoleByUserId(game, userId);
+    if (role === 'X' || role === 'O') game.playerLeft = role;
+    this.activeGame.set(gameId, game);
+    return game;
+  }
 }

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -231,4 +231,15 @@ export class GameService {
     this.activeGame.set(gameId, game);
     return game;
   }
+
+  getLiveGames() {
+    const waiting: GameState[] = [];
+    const playing: GameState[] = [];
+    const allGames = [...this.activeGame.values()];
+    for (const game of allGames) {
+      if (game.status === 'waiting') waiting.push(game);
+      else if (game.status === 'playing') playing.push(game);
+      return { waiting, playing };
+    }
+  }
 }

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -239,7 +239,7 @@ export class GameService {
     for (const game of allGames) {
       if (game.status === 'waiting') waiting.push(game);
       else if (game.status === 'playing') playing.push(game);
-      return { waiting, playing };
     }
+    return { waiting, playing };
   }
 }

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -66,9 +66,9 @@ export interface PlayingGame {
   playerO: PublicPlayerProfile | null;
 }
 
-export interface LivesGamesResponse {
-  waiting: WaitingGame;
-  playing: PlayingGame;
+export interface LiveGamesResponse {
+  waiting: WaitingGame[];
+  playing: PlayingGame[];
 }
 
 export interface GameState {

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -12,6 +12,8 @@ export type MovesGameHistory = number[];
 
 export type SpectatorsCnt = number;
 
+export type PlayerLeft = 'X' | 'O' | null;
+
 export interface PublicPlayerProfile {
   id: number;
   username: string;
@@ -72,4 +74,5 @@ export interface GameState {
   playerProfiles: PlayerProfilesInGame;
   movesGameHistory: MovesGameHistory;
   spectatCnt: SpectatorsCnt;
+  playerLeft: PlayerLeft;
 }

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -35,11 +35,10 @@ export interface Move extends BoardPosition {
 }
 
 export interface PlayerSeat {
-  socketId: string | null;
   ownerUserId: number | null;
+  socketId: string | null;
 }
-
-// to stock socketId and ownerUserId of client x and client o
+// to stock socketId of client x and client o
 export interface PlayersInGame {
   X: PlayerSeat;
   O: PlayerSeat;
@@ -54,6 +53,22 @@ export interface ScoreBoard {
   X: number;
   O: number;
   D: number;
+}
+
+export interface WaitingGame {
+  gameId: string;
+  playerX: PublicPlayerProfile | null;
+}
+
+export interface PlayingGame {
+  gameId: string;
+  playerX: PublicPlayerProfile | null;
+  playerO: PublicPlayerProfile | null;
+}
+
+export interface LivesGamesResponse {
+  waiting: WaitingGame;
+  playing: PlayingGame;
 }
 
 export interface GameState {

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,54 +1,68 @@
-import { Controller, Param, ParseIntPipe, Body, Get, Patch, UseGuards, Query , Inject, forwardRef} from '@nestjs/common';
+import {
+  Controller,
+  Param,
+  ParseIntPipe,
+  Body,
+  Get,
+  Patch,
+  UseGuards,
+  Query,
+  Inject,
+  forwardRef,
+} from '@nestjs/common';
 import { UsersService } from './users.service';
-import { UpdateUserDto} from './dto/update-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MatchesService } from 'src/modules/game/matches.service';
 import { AchievementsService } from 'src/modules/game/achievements.service';
 
 @ApiTags('Users')
-
 @Controller('users')
 export class UsersController {
+  constructor(
+    private usersService: UsersService,
+    @Inject(forwardRef(() => MatchesService))
+    private readonly matchServices: MatchesService,
+    private readonly achievementsService: AchievementsService,
+  ) {}
 
-	constructor(private usersService: UsersService, 
-		@Inject(forwardRef(() => MatchesService)) private readonly matchServices: MatchesService,
-		private readonly achievementsService: AchievementsService) {}
+  @ApiOperation({ summary: 'Get all of achievements of users' })
+  @Get(':id/achievements')
+  getAchievements(@Param('id', ParseIntPipe) id: number) {
+    return this.achievementsService.getAchievements(id);
+  }
 
+  @ApiOperation({ summary: 'Get leaderboard of users' })
+  @Get('leaderboard')
+  getLeaderboard(@Query('sortBy') sortBy: string) {
+    const safeSortBy = sortBy === 'xp' ? 'xp' : 'wins';
+    return this.matchServices.getGameLeaderboard(safeSortBy);
+  }
 
-	@ApiOperation({ summary: 'Get all of achievements of users' })
-	@Get(':id/achievements')
-	getAchievements(@Param('id', ParseIntPipe) id: number) {
-		return this.achievementsService.getAchievements(id)
-	}
+  @ApiOperation({ summary: 'Get all users' })
+  @Get()
+  getUsers() {
+    return this.usersService.getUsers();
+  }
 
-	@ApiOperation({ summary: 'Get leaderboard of users' })
-	@Get('leaderboard')
-	getLeaderboard( @Query('sortBy') sortBy: string) {
-		const safeSortBy = sortBy === "xp" ? "xp" : "wins"
-		return this.matchServices.getGameLeaderboard(safeSortBy)
-	}
-	
-	@ApiOperation({ summary: 'Get all users' })
-	@Get()
-	getUsers() {
-		return this.usersService.getUsers();
-	}
+  @ApiOperation({ summary: 'Get user by ID' })
+  @Get(':id')
+  getUser(@Param('id', ParseIntPipe) id: number) {
+    return this.usersService.getUser(id);
+  }
 
-	@ApiOperation({ summary: 'Get user by ID' })
-	@Get(':id')
-	getUser(@Param('id', ParseIntPipe) id: number) {
-		return this.usersService.getUser(id);
-	}
+  @ApiOperation({ summary: 'Update user' })
+  @Patch(':id')
+  updateUser(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    return this.usersService.updateUser(id, updateUserDto);
+  }
 
-	@ApiOperation({ summary: 'Update user' })
-	@Patch(':id')
-	updateUser(
-		@Param('id', ParseIntPipe) id: number,
-		@Body() updateUserDto: UpdateUserDto,
-	) {
-		return this.usersService.updateUser(id, updateUserDto);
-	}
-
+  @ApiOperation({ summary: 'Get history by ID' })
+  @Get(':id/history')
+  getHistory(@Param('id', ParseIntPipe) id: number) {
+    return this.matchServices.getFinishedGamesHistory(id);
+  }
 }
-
-

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,14 +1,14 @@
 import {
-  Controller,
-  Param,
-  ParseIntPipe,
-  Body,
-  Get,
-  Patch,
-  UseGuards,
-  Query,
-  Inject,
-  forwardRef,
+	Controller,
+	Param,
+	ParseIntPipe,
+	Body,
+	Get,
+	Patch,
+	UseGuards,
+	Query,
+	Inject,
+	forwardRef,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -19,50 +19,50 @@ import { AchievementsService } from 'src/modules/game/achievements.service';
 @ApiTags('Users')
 @Controller('users')
 export class UsersController {
-  constructor(
-    private usersService: UsersService,
-    @Inject(forwardRef(() => MatchesService))
-    private readonly matchServices: MatchesService,
-    private readonly achievementsService: AchievementsService,
-  ) {}
+	constructor(
+		private usersService: UsersService,
+		@Inject(forwardRef(() => MatchesService))
+		private readonly matchServices: MatchesService,
+		private readonly achievementsService: AchievementsService,
+	) {}
 
-  @ApiOperation({ summary: 'Get all of achievements of users' })
-  @Get(':id/achievements')
-  getAchievements(@Param('id', ParseIntPipe) id: number) {
-    return this.achievementsService.getAchievements(id);
-  }
+	@ApiOperation({ summary: 'Get all of achievements of users' })
+	@Get(':id/achievements')
+	getAchievements(@Param('id', ParseIntPipe) id: number) {
+		return this.achievementsService.getAchievements(id);
+	}
 
-  @ApiOperation({ summary: 'Get leaderboard of users' })
-  @Get('leaderboard')
-  getLeaderboard(@Query('sortBy') sortBy: string) {
-    const safeSortBy = sortBy === 'xp' ? 'xp' : 'wins';
-    return this.matchServices.getGameLeaderboard(safeSortBy);
-  }
+	@ApiOperation({ summary: 'Get leaderboard of users' })
+	@Get('leaderboard')
+	getLeaderboard(@Query('sortBy') sortBy: string) {
+		const safeSortBy = sortBy === 'xp' ? 'xp' : 'wins';
+		return this.matchServices.getGameLeaderboard(safeSortBy);
+	}
 
-  @ApiOperation({ summary: 'Get all users' })
-  @Get()
-  getUsers() {
-    return this.usersService.getUsers();
-  }
+	@ApiOperation({ summary: 'Get all users' })
+	@Get()
+	getUsers() {
+		return this.usersService.getUsers();
+	}
 
-  @ApiOperation({ summary: 'Get user by ID' })
-  @Get(':id')
-  getUser(@Param('id', ParseIntPipe) id: number) {
-    return this.usersService.getUser(id);
-  }
+	@ApiOperation({ summary: 'Get user by ID' })
+	@Get(':id')
+	getUser(@Param('id', ParseIntPipe) id: number) {
+		return this.usersService.getUser(id);
+	}
 
-  @ApiOperation({ summary: 'Update user' })
-  @Patch(':id')
-  updateUser(
-    @Param('id', ParseIntPipe) id: number,
-    @Body() updateUserDto: UpdateUserDto,
-  ) {
-    return this.usersService.updateUser(id, updateUserDto);
-  }
+	@ApiOperation({ summary: 'Update user' })
+	@Patch(':id')
+	updateUser(
+	@Param('id', ParseIntPipe) id: number,
+	@Body() updateUserDto: UpdateUserDto,
+	) {
+		return this.usersService.updateUser(id, updateUserDto);
+	}
 
-  @ApiOperation({ summary: 'Get history by ID' })
-  @Get(':id/history')
-  getHistory(@Param('id', ParseIntPipe) id: number) {
-    return this.matchServices.getFinishedGamesHistory(id);
-  }
+	@ApiOperation({ summary: 'Get history by ID' })
+	@Get(':id/history')
+	getHistory(@Param('id', ParseIntPipe) id: number) {
+		return this.matchServices.getFinishedGamesHistory(id);
+	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,9 +7,9 @@ import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import { Toaster } from "./components/ui/Sonner";
 import Dashboard from "./components/layout/Dashboard";
-import LeaderBoard from "@/pages/Leaderboard"
+import LeaderBoard from "@/pages/Leaderboard";
 import TwoFactorLogin from "./pages/TwoFactorLogin";
-
+import LiveGamesDisplay from "./pages/LiveGames";
 
 function App() {
   return (
@@ -17,17 +17,17 @@ function App() {
       <Routes>
         <Route element={<Dashboard />}>
           <Route path="/" element={<Home />} />
-          <Route path="/game" element={<Game />} />
+          <Route path="/game" element={<LiveGamesDisplay />} />
           <Route path="/game/:gameId" element={<Game />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/history" element={<History />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />
           <Route path="/leaderboard" element={<LeaderBoard />} />
-		  <Route path="/two-factor" element={<TwoFactorLogin />} />
+          <Route path="/two-factor" element={<TwoFactorLogin />} />
         </Route>
       </Routes>
-      <Toaster richColors theme="dark" position="bottom-right"/>
+      <Toaster richColors theme="dark" position="bottom-right" />
     </div>
   );
 }

--- a/frontend/src/Store/gameStore.ts
+++ b/frontend/src/Store/gameStore.ts
@@ -8,6 +8,7 @@ type GameStore = {
   game: GameState | null;
   error: string | null;
   playerRole: PlayerRole | null;
+  playerLeft: "X" | "O" | null;
 
   setGameId: (gameId: string | null) => void;
   setClient: (client: Socket | null) => void;
@@ -26,6 +27,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   game: null,
   error: null,
   playerRole: null,
+  playerLeft: null,
 
   setGameId: (gameId) => set({ gameId }),
   setClient: (client) => set({ client }),
@@ -56,7 +58,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   },
 
   leaveGame: () => {
-    const { client, gameId } = get();
+    const { gameId, client } = get();
     if (!client || !gameId) return;
     client.emit("leave_game", { gameId });
   },

--- a/frontend/src/Store/gameStore.ts
+++ b/frontend/src/Store/gameStore.ts
@@ -17,6 +17,7 @@ type GameStore = {
   resetGameState: () => void;
   playMove: (index: number) => void;
   requestReplay: () => void;
+  leaveGame: () => void;
 };
 
 export const useGameStore = create<GameStore>((set, get) => ({
@@ -52,6 +53,12 @@ export const useGameStore = create<GameStore>((set, get) => ({
     if (playerRole !== "X" && playerRole !== "O") return;
 
     client.emit("request_replay", { gameId });
+  },
+
+  leaveGame: () => {
+    const { client, gameId } = get();
+    if (!client || !gameId) return;
+    client.emit("leave_game", { gameId });
   },
 
   playMove: (index) => {

--- a/frontend/src/Store/liveGamesStore.ts
+++ b/frontend/src/Store/liveGamesStore.ts
@@ -7,7 +7,7 @@ type LiveGamesStore = {
   loading: boolean;
   error: string | null;
 
-  fetchGame: () => Promise<void>;
+  fetchGames: () => Promise<void>;
   reset: () => void;
 };
 
@@ -16,7 +16,7 @@ export const useLiveGamesStore = create<LiveGamesStore>((set) => ({
   loading: false,
   error: null,
 
-  fetchGame: async () => {
+  fetchGames: async () => {
     set({ loading: true, error: null });
     try {
       const data = await gameApi.getLiveGames();

--- a/frontend/src/Store/liveGamesStore.ts
+++ b/frontend/src/Store/liveGamesStore.ts
@@ -1,0 +1,10 @@
+import type { LivesGamesResponse } from "@/type/game.types";
+
+type LiveGameStore = {
+  games: LivesGamesResponse;
+  loading: boolean;
+  error: string | null;
+
+  fetchGame: () => Promise<void>;
+  reset: () => void;
+};

--- a/frontend/src/Store/liveGamesStore.ts
+++ b/frontend/src/Store/liveGamesStore.ts
@@ -1,10 +1,39 @@
-import type { LivesGamesResponse } from "@/type/game.types";
+import { gameApi } from "@/services/gameApi";
+import type { LiveGamesResponse } from "@/type/game.types";
+import { create } from "zustand";
 
-type LiveGameStore = {
-  games: LivesGamesResponse;
+type LiveGamesStore = {
+  games: LiveGamesResponse;
   loading: boolean;
   error: string | null;
 
   fetchGame: () => Promise<void>;
   reset: () => void;
 };
+
+export const useLiveGamesStore = create<LiveGamesStore>((set) => ({
+  games: { waiting: [], playing: [] },
+  loading: false,
+  error: null,
+
+  fetchGame: async () => {
+    set({ loading: true, error: null });
+    try {
+      const data = await gameApi.getLiveGames();
+      set({ games: data, loading: false });
+    } catch (error) {
+      console.error("Error fetching games:", error);
+      set({
+        error: error instanceof Error ? error.message : "Failed to fetch games",
+        loading: false,
+      });
+    }
+  },
+
+  reset: () =>
+    set({
+      games: { waiting: [], playing: [] },
+      loading: false,
+      error: null,
+    }),
+}));

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -4,6 +4,8 @@ import type { CellValue } from "../type/game.types";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
 
 function truncateUserName(username: string, maxLength = 12): string {
   if (!username) return "";
@@ -119,10 +121,10 @@ export default function Board() {
         <h2> Waiting for oppenent...</h2>
         <p>Share this link to invite someone:</p>
         <div className="flex gap-2 justify-center mt-4">
-          <input value={urlInvit} className="..."></input>
-          <button onClick={() => navigator.clipboard.writeText(urlInvit)}>
+          <Input readOnly value={urlInvit} className="..."></Input>
+          <Button onClick={() => navigator.clipboard.writeText(urlInvit)}>
             Copy
-          </button>
+          </Button>
         </div>
       </div>
     );

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -3,9 +3,10 @@ import { useGameStore } from "../Store/gameStore";
 import type { CellValue } from "../type/game.types";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { toast } from "sonner";
 
 function truncateUserName(username: string, maxLength = 12): string {
   if (!username) return "";
@@ -81,6 +82,14 @@ export default function Board() {
   const navigate = useNavigate();
 
   const [timeLeft, setTimeLeft] = useState(TURN_TIMEOUT_SECONDS);
+  const playerLeftToast = useRef(false);
+
+  useEffect(() => {
+    if (game?.playerLeft) {
+      toast.warning("Opponent left - no replay!");
+      playerLeftToast.current = true;
+    }
+  }, [game?.playerLeft]);
 
   useEffect(() => {
     if (!game || game.status !== "playing") {

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -2,7 +2,7 @@ import Square from "./Square";
 import { useGameStore } from "../Store/gameStore";
 import type { CellValue } from "../type/game.types";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 
 function truncateUserName(username: string, maxLength = 12): string {
@@ -65,7 +65,8 @@ function getEndGameMessage(
 const TURN_TIMEOUT_SECONDS = 30;
 
 export default function Board() {
-  const { game, error, playMove, playerRole, requestReplay } = useGameStore();
+  const { gameId, game, error, playMove, playerRole, requestReplay } =
+    useGameStore();
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -110,6 +111,15 @@ export default function Board() {
   }
 
   const { board, currentPlayer, status, winner, toDisapear } = game;
+
+  if (status === "waiting" && playerRole === "X") {
+    const urlInvit = `${window.location.origin}/game/${gameId}`;
+    return (
+      <div>
+        <h2> Waiting Oppenent</h2>
+      </div>
+    );
+  }
 
   const playerXName = game.playerProfiles?.X?.username || "Player X";
   const playerOName = game.playerProfiles?.O?.username || "Player O";

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -185,6 +185,12 @@ export default function Board() {
     playerONameTrunc,
   );
 
+  const xDisconnect =
+    game.players.X.socketId === null && game.players.X.ownerUserId !== null;
+  const oDisconnect =
+    game.players.O.socketId === null && game.players.O.ownerUserId !== null;
+  const oppenentDisconnect =
+    playerRole === "X" ? oDisconnect : playerRole === "O" ? xDisconnect : false;
   return (
     <div className="relative inline-block text-center p-4">
       {status !== "finished" && (
@@ -275,6 +281,12 @@ export default function Board() {
           {t("game.waitingMove", {
             defaultValue: "Waiting for opponent move...",
           })}
+        </div>
+      )}
+
+      {status === "playing" && oppenentDisconnect && (
+        <div className="border border-orange-400 bg-orange-500/20 px-4 py-3 text-orange-100">
+          Opponent disconnected — waiting 20s for reconnection...
         </div>
       )}
 

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -83,6 +83,14 @@ export default function Board() {
 
   const [timeLeft, setTimeLeft] = useState(TURN_TIMEOUT_SECONDS);
   const playerLeftToast = useRef(false);
+  const oldOppDiscnct = useRef(false);
+
+  const xDisconnect =
+    game?.players.X.socketId === null && game.players.X.ownerUserId !== null;
+  const oDisconnect =
+    game?.players.O.socketId === null && game.players.O.ownerUserId !== null;
+  const opponentDisconnect =
+    playerRole === "X" ? oDisconnect : playerRole === "O" ? xDisconnect : false;
 
   useEffect(() => {
     if (game?.playerLeft) {
@@ -107,6 +115,12 @@ export default function Board() {
     return () => clearInterval(interval);
   }, [game?.status, game?.lastMove]);
 
+  useEffect(() => {
+    if (oldOppDiscnct.current && !opponentDisconnect) {
+      toast.success("Opponent reconnected!");
+    }
+    oldOppDiscnct.current = opponentDisconnect;
+  }, [opponentDisconnect]);
   if (error && !game) {
     return (
       <div className="text-white text-center p-8">
@@ -185,12 +199,6 @@ export default function Board() {
     playerONameTrunc,
   );
 
-  const xDisconnect =
-    game.players.X.socketId === null && game.players.X.ownerUserId !== null;
-  const oDisconnect =
-    game.players.O.socketId === null && game.players.O.ownerUserId !== null;
-  const oppenentDisconnect =
-    playerRole === "X" ? oDisconnect : playerRole === "O" ? xDisconnect : false;
   return (
     <div className="relative inline-block text-center p-4">
       {status !== "finished" && (
@@ -284,7 +292,7 @@ export default function Board() {
         </div>
       )}
 
-      {status === "playing" && oppenentDisconnect && (
+      {status === "playing" && opponentDisconnect && (
         <div className="border border-orange-400 bg-orange-500/20 px-4 py-3 text-orange-100">
           Opponent disconnected — waiting 20s for reconnection...
         </div>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -115,10 +115,20 @@ export default function Board() {
   if (status === "waiting" && playerRole === "X") {
     const urlInvit = `${window.location.origin}/game/${gameId}`;
     return (
-      <div>
-        <h2> Waiting Oppenent</h2>
+      <div className="text-center p-10">
+        <h2> Waiting for oppenent...</h2>
+        <p>Share this link to invite someone:</p>
+        <div className="flex gap-2 justify-center mt-4">
+          <input value={urlInvit} className="..."></input>
+          <button onClick={() => navigator.clipboard.writeText(urlInvit)}>
+            Copy
+          </button>
+        </div>
       </div>
     );
+  }
+  {
+    /* <button> </div></button> */
   }
 
   const playerXName = game.playerProfiles?.X?.username || "Player X";

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -126,11 +126,9 @@ export default function Board() {
             Copy
           </Button>
         </div>
+        <Button onClick={() => navigate("/")}>leave the game</Button>
       </div>
     );
-  }
-  {
-    /* <button> </div></button> */
   }
 
   const playerXName = game.playerProfiles?.X?.username || "Player X";

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -2,7 +2,7 @@ import Square from "./Square";
 import { useGameStore } from "../Store/gameStore";
 import type { CellValue } from "../type/game.types";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -67,8 +67,16 @@ function getEndGameMessage(
 const TURN_TIMEOUT_SECONDS = 30;
 
 export default function Board() {
-  const { gameId, game, error, playMove, playerRole, requestReplay } =
-    useGameStore();
+  const {
+    gameId,
+    client,
+    game,
+    error,
+    playMove,
+    playerRole,
+    requestReplay,
+    leaveGame,
+  } = useGameStore();
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -126,7 +134,14 @@ export default function Board() {
             Copy
           </Button>
         </div>
-        <Button onClick={() => navigate("/")}>leave the game</Button>
+        <Button
+          onClick={() => {
+            client;
+            navigate("/");
+          }}
+        >
+          leave the game
+        </Button>
       </div>
     );
   }
@@ -308,7 +323,19 @@ export default function Board() {
 
             <button
               className="bg-fuchsia-500 hover:bg-fuchsia-600 text-white font-bold py-2 px-6 rounded-lg transition-colors"
-              onClick={() => navigate("/")}
+              onClick={() => {
+                leaveGame();
+                console.log(
+                  "socket",
+                  client,
+                  "role",
+                  playerRole,
+                  "click en backhome from gameid =",
+                  gameId,
+                  "and send leave_game",
+                );
+                navigate("/");
+              }}
             >
               {t("game.backHome", { defaultValue: "Back to home" })}
             </button>

--- a/frontend/src/components/Board.tsx
+++ b/frontend/src/components/Board.tsx
@@ -136,7 +136,7 @@ export default function Board() {
         </div>
         <Button
           onClick={() => {
-            client;
+            // client;
             navigate("/");
           }}
         >
@@ -288,13 +288,16 @@ export default function Board() {
             </div>
 
             <p className="text-sm text-gray-500 text-center">
-              {playerRole === "X" || playerRole === "O"
-                ? "You can request a replay"
-                : "Players try to decide whether to replay"}
+              {game.playerLeft
+                ? "Opponent left - replay unavailable"
+                : playerRole === "X" || playerRole === "O"
+                  ? "You can request a replay"
+                  : "Players try to decide whether to replay"}
             </p>
 
-            {(playerRole === "X" || playerRole === "O") && (
+            {(playerRole === "X" || playerRole === "O") && !game.playerLeft && (
               <>
+                {/* if (game.playerLeft) toast.warning("Opponent left - no replay!"); */}
                 <button
                   className="bg-fuchsia-500 hover:bg-fuchsia-600 text-white font-bold py-2 px-6 rounded-lg transition-colors"
                   onClick={requestReplay}

--- a/frontend/src/components/layout/Dashboard.tsx
+++ b/frontend/src/components/layout/Dashboard.tsx
@@ -42,15 +42,17 @@ export default function Dashboard() {
     getCurrentUser()
   }, [])
 
-  async function handleLogout() {
-    try {
-      setUser(null)
-      toast.success(t("auth.logoutSuccess"))
-      navigate("/")
-    } catch {
-      setUser(null)
-    }
-  }
+	async function handleLogout() {
+			try {
+				const response = await userService.userLogout()
+
+				setUser(null)
+				toast.success(response.message ?? t("auth.logoutSuccess"))
+				navigate("/")
+			} catch {
+				setUser(null)
+			}
+		}
 
   async function handleLoginSuccess() {
     const result = await userService.getMe()

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -61,8 +61,9 @@ export default function Game() {
       useGameStore.getState().setError(gameErrorMsg(payload.message));
     });
 
-    client.on("opponent_left", () => {
-      toast.warning("oppenent left - no replay");
+    client.on("opponent_left", (payload) => {
+      console.log("OPPONENT_LEFT RECEIVED:", payload);
+      toast.warning(payload?.message ?? "Opponent left - no replay");
     });
 
     return () => {

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -4,6 +4,7 @@ import { io } from "socket.io-client";
 import { useParams } from "react-router-dom";
 import { useGameStore } from "../Store/gameStore";
 import { gameErrorMsg } from "@/lib/gameErrorMsg";
+import { toast } from "sonner";
 
 export default function Game() {
   const { gameId } = useParams<{ gameId: string }>();
@@ -58,6 +59,10 @@ export default function Game() {
         return;
       }
       useGameStore.getState().setError(gameErrorMsg(payload.message));
+    });
+
+    client.on("opponent_left", () => {
+      toast.warning("oppenent left - no replay");
     });
 
     return () => {

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -61,11 +61,6 @@ export default function Game() {
       useGameStore.getState().setError(gameErrorMsg(payload.message));
     });
 
-    client.on("opponent_left", (payload) => {
-      console.log("OPPONENT_LEFT RECEIVED:", payload);
-      toast.warning(payload?.message ?? "Opponent left - no replay");
-    });
-
     return () => {
       console.log("deconexion du socket");
       client.disconnect();

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -4,7 +4,6 @@ import { io } from "socket.io-client";
 import { useParams } from "react-router-dom";
 import { useGameStore } from "../Store/gameStore";
 import { gameErrorMsg } from "@/lib/gameErrorMsg";
-import { toast } from "sonner";
 
 export default function Game() {
   const { gameId } = useParams<{ gameId: string }>();

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -1,29 +1,20 @@
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Avatar } from "@/components/ui/Avatar";
+import { useLiveGamesStore } from "@/Store/liveGamesStore";
 
 export default function LiveGamesDisplay() {
+  const games = useLiveGamesStore((state) => state.games);
   return (
     <div className="p-8 space-y-10">
       <section>
         <h2>Open games</h2>
-        <p>Waiting games : {}</p>
-        <Card>
-          <Avatar fallback="J" size="md" />
-          <span> John is waiting for oppenennt</span>
-          <Button>Join</Button>
-          <p>No open games available</p>
-        </Card>
+        <p>Waiting: {games.waiting.length}</p>
       </section>
+
       <section>
         <h2>Live games</h2>
-        <Card>
-          <Avatar fallback="X" size="md" />
-          <Avatar fallback="O" size="md" />
-          <span> PlyerO vs PlayerX</span>
-          <Button variant={"secondary"}>Watch</Button>
-          <p>No live games available</p>
-        </Card>
+        <p>Playing: {games.playing.length}</p>
       </section>
     </div>
   );

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -3,11 +3,15 @@ import { Button } from "@/components/ui/Button";
 import { Avatar } from "@/components/ui/Avatar";
 import { useLiveGamesStore } from "@/Store/liveGamesStore";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { Spinner } from "@/components/ui/Spinner";
 
 export default function LiveGamesDisplay() {
+  const navigate = useNavigate();
+
   const { games, loading } = useLiveGamesStore();
-  const fetchGames = useLiveGamesStore((state) => state.fetchGame);
+  const fetchGames = useLiveGamesStore((state) => state.fetchGames);
+
   useEffect(() => {
     fetchGames();
   }, [fetchGames]);
@@ -27,13 +31,16 @@ export default function LiveGamesDisplay() {
 
         <span>{game.playerX?.username} is waiting</span>
 
-        <Button>Join</Button>
+        <Button onClick={() => navigate(`/game/${game.gameId}`)}>Join</Button>
       </Card>
     ));
   }
 
   function renderPlayingGames() {
-    if (games.playing.length === 0) return <p>No game to spectate</p>;
+    if (games.playing.length === 0) {
+      return <p>No game to spectate</p>;
+    }
+
     return games.playing.map((game) => (
       <Card key={game.gameId}>
         <Avatar
@@ -41,15 +48,23 @@ export default function LiveGamesDisplay() {
           fallback={game.playerX?.username?.[0] || "?"}
           size="md"
         />
+
         <Avatar
           src={game.playerO?.avatar || undefined}
           fallback={game.playerO?.username?.[0] || "?"}
           size="md"
         />
+
         <span>
           {game.playerX?.username || "?"} vs {game.playerO?.username || "?"}
         </span>
-        <Button variant="secondary">Watch</Button>
+
+        <Button
+          variant="secondary"
+          onClick={() => navigate(`/game/${game.gameId}`)}
+        >
+          Watch
+        </Button>
       </Card>
     ));
   }
@@ -57,6 +72,7 @@ export default function LiveGamesDisplay() {
   if (loading) {
     return <Spinner variant="cyan" size="lg" />;
   }
+
   return (
     <div className="p-8 space-y-10">
       <section>

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -1,0 +1,7 @@
+export default function LiveGamesDisplay() {
+  return (
+    <div className="p-8 space-y-10">
+      <h1>LiveGamesDisplay...</h1>
+    </div>
+  );
+}

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -8,12 +8,19 @@ export default function LiveGamesDisplay() {
       <section>
         <h2>Open games</h2>
         <Card>
+          <Avatar fallback="J" size="md" />
+          <span> John is waiting for oppenennt</span>
+          <Button>Join</Button>
           <p>No open games available</p>
         </Card>
       </section>
       <section>
         <h2>Live games</h2>
         <Card>
+          <Avatar fallback="X" size="md" />
+          <Avatar fallback="O" size="md" />
+          <span> PlyerO vs PlayerX</span>
+          <Button variant={"secondary"}>Watch</Button>
           <p>No live games available</p>
         </Card>
       </section>

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -11,16 +11,30 @@ export default function LiveGamesDisplay() {
   useEffect(() => {
     fetchGames();
   }, [fetchGames]);
+
   return (
     <div className="p-8 space-y-10">
       <section>
         <h2>Open games</h2>
         <p>Waiting: {games.waiting.length}</p>
+
+        <Card>
+          <Avatar fallback="J" size="md" />
+          <span>John is waiting for an opponent</span>
+          <Button>Join</Button>
+        </Card>
       </section>
 
       <section>
         <h2>Live games</h2>
         <p>Playing: {games.playing.length}</p>
+
+        <Card>
+          <Avatar fallback="A" size="md" />
+          <Avatar fallback="B" size="md" />
+          <span>Alice vs Bob</span>
+          <Button variant="secondary">Watch</Button>
+        </Card>
       </section>
     </div>
   );

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -7,6 +7,7 @@ export default function LiveGamesDisplay() {
     <div className="p-8 space-y-10">
       <section>
         <h2>Open games</h2>
+        <p>Waiting games : {}</p>
         <Card>
           <Avatar fallback="J" size="md" />
           <span> John is waiting for oppenennt</span>

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -24,7 +24,7 @@ export default function LiveGamesDisplay() {
     return games.waiting.map((game) => (
       <Card key={game.gameId}>
         <Avatar
-          src={game.playerX?.avatar}
+          src={game.playerX?.avatar || undefined}
           fallback={game.playerX?.username[0] || "?"}
           size="md"
         />

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -3,26 +3,43 @@ import { Button } from "@/components/ui/Button";
 import { Avatar } from "@/components/ui/Avatar";
 import { useLiveGamesStore } from "@/Store/liveGamesStore";
 import { useEffect } from "react";
+import { Spinner } from "@/components/ui/Spinner";
 
 export default function LiveGamesDisplay() {
-  const games = useLiveGamesStore((state) => state.games);
+  const { games, loading } = useLiveGamesStore();
   const fetchGames = useLiveGamesStore((state) => state.fetchGame);
-
   useEffect(() => {
     fetchGames();
   }, [fetchGames]);
 
+  function renderWaitingGames() {
+    if (games.waiting.length === 0) {
+      return <p>No open games</p>;
+    }
+
+    return games.waiting.map((game) => (
+      <Card key={game.gameId}>
+        <Avatar
+          src={game.playerX?.avatar}
+          fallback={game.playerX?.username[0] || "?"}
+          size="md"
+        />
+
+        <span>{game.playerX?.username} is waiting</span>
+
+        <Button>Join</Button>
+      </Card>
+    ));
+  }
+
+  if (loading) {
+    return <Spinner variant="cyan" size="lg" />;
+  }
   return (
     <div className="p-8 space-y-10">
       <section>
         <h2>Open games</h2>
-        <p>Waiting: {games.waiting.length}</p>
-
-        <Card>
-          <Avatar fallback="J" size="md" />
-          <span>John is waiting for an opponent</span>
-          <Button>Join</Button>
-        </Card>
+        {renderWaitingGames()}
       </section>
 
       <section>

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -1,7 +1,12 @@
 export default function LiveGamesDisplay() {
   return (
     <div className="p-8 space-y-10">
-      <h1>LiveGamesDisplay...</h1>
+      <section>
+        <h2>Choose a game to play</h2>
+      </section>
+      <section>
+        <h2>Choose a game and enter to spectate</h2>
+      </section>
     </div>
   );
 }

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -32,6 +32,28 @@ export default function LiveGamesDisplay() {
     ));
   }
 
+  function renderPlayingGames() {
+    if (games.playing.length === 0) return <p>No game to spectate</p>;
+    return games.playing.map((game) => (
+      <Card key={game.gameId}>
+        <Avatar
+          src={game.playerX?.avatar || undefined}
+          fallback={game.playerX?.username?.[0] || "?"}
+          size="md"
+        />
+        <Avatar
+          src={game.playerO?.avatar || undefined}
+          fallback={game.playerO?.username?.[0] || "?"}
+          size="md"
+        />
+        <span>
+          {game.playerX?.username || "?"} vs {game.playerO?.username || "?"}
+        </span>
+        <Button variant="secondary">Watch</Button>
+      </Card>
+    ));
+  }
+
   if (loading) {
     return <Spinner variant="cyan" size="lg" />;
   }
@@ -44,14 +66,7 @@ export default function LiveGamesDisplay() {
 
       <section>
         <h2>Live games</h2>
-        <p>Playing: {games.playing.length}</p>
-
-        <Card>
-          <Avatar fallback="A" size="md" />
-          <Avatar fallback="B" size="md" />
-          <span>Alice vs Bob</span>
-          <Button variant="secondary">Watch</Button>
-        </Card>
+        {renderPlayingGames()}
       </section>
     </div>
   );

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -2,9 +2,15 @@ import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { Avatar } from "@/components/ui/Avatar";
 import { useLiveGamesStore } from "@/Store/liveGamesStore";
+import { useEffect } from "react";
 
 export default function LiveGamesDisplay() {
   const games = useLiveGamesStore((state) => state.games);
+  const fetchGames = useLiveGamesStore((state) => state.fetchGame);
+
+  useEffect(() => {
+    fetchGames();
+  }, [fetchGames]);
   return (
     <div className="p-8 space-y-10">
       <section>

--- a/frontend/src/pages/LiveGames.tsx
+++ b/frontend/src/pages/LiveGames.tsx
@@ -1,11 +1,21 @@
+import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
+import { Avatar } from "@/components/ui/Avatar";
+
 export default function LiveGamesDisplay() {
   return (
     <div className="p-8 space-y-10">
       <section>
-        <h2>Choose a game to play</h2>
+        <h2>Open games</h2>
+        <Card>
+          <p>No open games available</p>
+        </Card>
       </section>
       <section>
-        <h2>Choose a game and enter to spectate</h2>
+        <h2>Live games</h2>
+        <Card>
+          <p>No live games available</p>
+        </Card>
       </section>
     </div>
   );

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,303 +1,279 @@
 // import avatarImg from "/avatar.png"
-import { useEffect, useState } from 'react'
-import { userService } from '../services/userService'
-import { useTranslation } from "react-i18next"
-import { Input } from "@/components/ui/Input"
-import { Button } from "@/components/ui/Button"
+import { useEffect, useState } from "react";
+import { userService } from "../services/userService";
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
 import { useOutletContext } from "react-router";
-import { Spinner } from "@/components/ui/Spinner"
+import { Spinner } from "@/components/ui/Spinner";
 import { toast } from "sonner";
 // import { zodResolver } from "@hookform/resolvers/zod";
 // import { useNavigate } from 'react-router-dom';
-import { Avatar } from "@/components/ui/Avatar"
-import type { Match } from "@/lib/match"
-import { Winrate } from '@/components/ui/Winrate'
-import { LevelProgress } from '@/components/ui/Level'
+import { Avatar } from "@/components/ui/Avatar";
+import type { Match } from "@/lib/match";
+import { Winrate } from "@/components/ui/Winrate";
+import { LevelProgress } from "@/components/ui/Level";
 
 interface User {
-    id: number
-    username: string,
-    wins: number,
-    losses: number,
-    draws: number,
-    bio: string,
-    avatar: string,
-    xp: number
-	isTwoFactorEnabled: boolean
+  id: number;
+  username: string;
+  wins: number;
+  losses: number;
+  draws: number;
+  bio: string;
+  avatar: string;
+  xp: number;
+  isTwoFactorEnabled: boolean;
 }
 
 export default function Profile() {
+  const { t } = useTranslation();
+  const [user, setUser] =
+    useOutletContext<
+      [User | null, React.Dispatch<React.SetStateAction<User | null>>]
+    >();
+  const [matches, setMatches] = useState<Match[]>([]);
 
+  const [isEdit, isInEdit] = useState(false);
+  const [userName, setUserName] = useState(user?.username || "");
+  const [bio, setBio] = useState(user?.bio || "");
+  const [loading, setLoading] = useState(true);
+  //   const navigate = useNavigate()
 
-  const { t } = useTranslation()
-  const [user, setUser] = useOutletContext<[User | null, React.Dispatch<React.SetStateAction<User | null>>]>();
-  const [matches, setMatches] = useState<Match[]>([])
-
-  const [isEdit, isInEdit] = useState(false)
-  const [userName, setUserName] = useState(user?.username || "")
-  const [bio, setBio] = useState(user?.bio || "")
-  const [loading, setLoading] = useState(true)
-//   const navigate = useNavigate()
-
-  const [twoFactorCode, setTwoFactorCode] = useState("")
-  const [qrCodeDataUrl, setQrCodeDataUrl] = useState("")
-  const [isTwoFactorLoading, setIsTwoFactorLoading] = useState(false)
+  const [twoFactorCode, setTwoFactorCode] = useState("");
+  const [qrCodeDataUrl, setQrCodeDataUrl] = useState("");
+  const [isTwoFactorLoading, setIsTwoFactorLoading] = useState(false);
 
   useEffect(() => {
     if (user) {
-      setUserName(user.username)
-      setBio(user.bio)
-    }
-  }, [user])
+      setUserName(user.username);
+      setBio(user.bio);
 
-    async function handleSave() {
-        if (!user) return;
-        if (isEdit) {
-          try {
-            await userService.updateUser(user.id, { username: userName, bio: bio })
-            setUser({... user, username: userName, bio: bio})
-            toast.info( t("auth.buttons.edit"))
-          } catch (error: any) {
-              const serverMessage = error.response?.data?.message || error.message
-			        const finalMessage = Array.isArray(serverMessage) ? serverMessage[0] : serverMessage
-              toast.error(t("auth.error") + finalMessage)
-          }
+      async function fetchhistory() {
+        try {
+          const data = await userService.getUserHistory(user!.id);
+          setMatches(data);
+        } catch (error) {
+          console.error("Failed to fetch history:", error);
+        } finally {
+          setLoading(false);
         }
-        isInEdit(!isEdit)
+      }
+      fetchhistory();
     }
+  }, [user]);
 
-	async function handleEnableTwoFactor() {
-		if (!user) return
+  // DEBUG
+  console.log(matches);
 
-		try {
-			setIsTwoFactorLoading(true)
-			const result = await userService.enableTwoFactor()
-			setQrCodeDataUrl(result.qrCodeDataUrl)
-			toast.success("2FA setup started")
-		} catch (error: any) {
-		const serverMessage = error.response?.data?.message || error.message
-		const finalMessage = Array.isArray(serverMessage) ? serverMessage[0] : serverMessage
-		toast.error(t("auth.error") + finalMessage)
-		} finally {
-			setIsTwoFactorLoading(false)
-		}
-	}
-
-	async function handleVerifyTwoFactor() {
-		if (!user) return
-
-		try {
-			setIsTwoFactorLoading(true)
-			const result = await userService.verifyTwoFactorSetup(twoFactorCode)
-			toast.success(result.message)
-
-			const refreshedUser = await userService.getMe()
-			setUser(refreshedUser)
-
-			setTwoFactorCode("")
-			setQrCodeDataUrl("")
-		} catch (error: any) {
-			const serverMessage = error.response?.data?.message || error.message
-			const finalMessage = Array.isArray(serverMessage) ? serverMessage[0] : serverMessage
-			toast.error(t("auth.error") + finalMessage)
-		} finally {
-			setIsTwoFactorLoading(false)
-		}
-	}
-
-    useEffect(() => {
-      if (user) {
-        setUserName(user.username);
-        setBio(user.bio);
-
-        async function fetchhistory() {
-          try {
-            const data = await userService.getUserHistory(user!.id);
-            setMatches(data);
-          } catch (error) {
-            console.error("Failed to fetch history:", error);
-          }
-          finally {
-            setLoading(false)
-          }
-        }
-        fetchhistory();
-      }
-    }, [user]);
-
-    // DEBUG
-    console.log(matches)
-
-      if (!user || loading) {
-        return (
-          <div className="flex justify-center mt-20">
-            <Spinner variant="cyan" size="lg" />
-          </div>
-        );
-      }
-
+  if (!user || loading) {
     return (
-        <section className="w-full flex justify-center">
+      <div className="flex justify-center mt-20">
+        <Spinner variant="cyan" size="lg" />
+      </div>
+    );
+  }
 
-          <div className="relative bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl p-8 overflow-hidden">
+  async function handleSave() {
+    if (!user) return;
+    if (isEdit) {
+      try {
+        await userService.updateUser(user.id, { username: userName, bio: bio });
+        setUser({ ...user, username: userName, bio: bio });
+        toast.info(t("auth.buttons.edit"));
+      } catch (error: any) {
+        const serverMessage = error.response?.data?.message || error.message;
+        const finalMessage = Array.isArray(serverMessage)
+          ? serverMessage[0]
+          : serverMessage;
+        toast.error(t("auth.error") + finalMessage);
+      }
+    }
+    isInEdit(!isEdit);
+  }
 
-            {/* GLOW BACKGROUND */}
-            <div className="absolute -top-20 -right-20 w-40 h-40 bg-cyan-500/20 rounded-full blur-3xl"></div>
-            <div className="absolute -bottom-20 -left-20 w-40 h-40 bg-purple-500/20 rounded-full blur-3xl"></div>
+  async function handleEnableTwoFactor() {
+    if (!user) return;
 
-            {/* HEADER */}
-            <div className="relative flex flex-col items-center gap-4">
+    try {
+      setIsTwoFactorLoading(true);
+      const result = await userService.enableTwoFactor();
+      setQrCodeDataUrl(result.qrCodeDataUrl);
+      toast.success("2FA setup started");
+    } catch (error: any) {
+      const serverMessage = error.response?.data?.message || error.message;
+      const finalMessage = Array.isArray(serverMessage)
+        ? serverMessage[0]
+        : serverMessage;
+      toast.error(t("auth.error") + finalMessage);
+    } finally {
+      setIsTwoFactorLoading(false);
+    }
+  }
 
-            {/* AVATAR */}
-            <div className="relative group">
-              <Avatar
-                src={user.avatar}
-                alt={user.username}
-                size="lg"
-                className="border border-white/20 z-10 relative"/>
-              <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-md opacity-0 group-hover:opacity-100 transition"></div>
-            </div>
+  async function handleVerifyTwoFactor() {
+    if (!user) return;
 
-              {/* USERNAME */}
-              {isEdit ? (
-                <Input
-                  value={userName}
-                  onChange={(e) => setUserName(e.target.value)}
-                  className="text-center"/>
-              ) : (
-                <h1 className="text-2xl font-bold tracking-wide">
-                  {user.username}
-                </h1>
-              )}
+    try {
+      setIsTwoFactorLoading(true);
+      const result = await userService.verifyTwoFactorSetup(twoFactorCode);
+      toast.success(result.message);
 
-            </div>
+      const refreshedUser = await userService.getMe();
+      setUser(refreshedUser);
 
-            {/* STATS */}
-            <div className="mt-8 grid grid-cols-2 gap-4 text-center">
-              {[
-                { label: t("profile.stats.wins"), value: user.wins },
-                { label: t("profile.stats.losses"), value: user.losses },
-              ].map((stat, i) => (
-                <div
-                  key={i}
-                  className="bg-white/5 rounded-lg py-4 border border-white/10 hover:scale-105 transition">
+      setTwoFactorCode("");
+      setQrCodeDataUrl("");
+    } catch (error: any) {
+      const serverMessage = error.response?.data?.message || error.message;
+      const finalMessage = Array.isArray(serverMessage)
+        ? serverMessage[0]
+        : serverMessage;
+      toast.error(t("auth.error") + finalMessage);
+    } finally {
+      setIsTwoFactorLoading(false);
+    }
+  }
 
-                  <p className="text-xs text-white/50">
-                    {stat.label}
-                  </p>
+  return (
+    <section className="w-full flex justify-center">
+      <div className="relative bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl p-8 overflow-hidden">
+        {/* GLOW BACKGROUND */}
+        <div className="absolute -top-20 -right-20 w-40 h-40 bg-cyan-500/20 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-20 -left-20 w-40 h-40 bg-purple-500/20 rounded-full blur-3xl"></div>
 
-                  <p className="font-bold text-lg">
-                    {stat.value}
-                  </p>
-
-                </div>
-              ))}
-            </div>
-
-            {/* WINRATE */}
-            <Winrate
-              wins={user.wins}
-              losses={user.losses}
-              draws={user.draws}
+        {/* HEADER */}
+        <div className="relative flex flex-col items-center gap-4">
+          {/* AVATAR */}
+          <div className="relative group">
+            <Avatar
+              src={user.avatar}
+              alt={user.username}
+              size="lg"
+              className="border border-white/20 z-10 relative"
             />
-
-            {/* Level */}
-            <LevelProgress
-              xp={user.xp}
-            />
-
-            {/* BIO */}
-            <div className="mt-8">
-
-              <p className="text-white/50 text-sm mb-2">
-                {t("profile.bio")}
-              </p>
-
-              {isEdit ? (
-                <textarea
-                  value={bio}
-                  onChange={(e) => setBio(e.target.value)}
-                  className="w-full bg-transparent border border-white/20 rounded px-3 py-2 focus:outline-none focus:border-cyan-400 transition resize-none"
-                  rows={3}
-                />
-              ) : (
-                <p className="text-sm leading-relaxed text-white/80">
-                  {user.bio}
-                </p>
-              )}
-
-            </div>
-						{/* 2FA */}
-			<div className="mt-8">
-				<p className="text-white/50 text-sm mb-2">
-					Two-Factor Authentication
-				</p>
-
-				{user.isTwoFactorEnabled ? (
-				<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
-					<p className="text-sm text-green-400 font-medium">
-						2FA is enabled on your account.
-					</p>
-				</div>
-				) : (
-				<div className="space-y-4">
-					<Button
-						type="button"
-						onClick={handleEnableTwoFactor}
-						disabled={isTwoFactorLoading}
-						className="w-full"
-					>
-						{isTwoFactorLoading ? "Loading..." : "Enable 2FA"}
-					</Button>
-
-					{qrCodeDataUrl && (
-						<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10 space-y-4">
-							<img
-								src={qrCodeDataUrl}
-								alt="2FA QR code"
-								className="mx-auto rounded-lg bg-white p-2"
-						/>
-
-						<Input
-							value={twoFactorCode}
-							onChange={(e) => setTwoFactorCode(e.target.value)}
-							placeholder="Enter 6-digit code"
-							maxLength={6}
-						/>
-
-						<Button
-							type="button"
-							onClick={handleVerifyTwoFactor}
-							disabled={isTwoFactorLoading || twoFactorCode.length !== 6}
-							className="w-full"
-						>
-							{isTwoFactorLoading ? "Verifying..." : "Verify 2FA"}
-						</Button>
-
-						<Button
-							type="button"
-							variant="secondary"
-							onClick={handleEnableTwoFactor}
-							disabled={isTwoFactorLoading}
-							className="w-full"
-						>
-							Regenerate QR
-						</Button>
-					</div>
-					)}
-				</div>
-				)}
-			</div>
-
-            {/* BUTTON */}
-            <Button
-              onClick={handleSave}
-              className="mt-8">
-              {isEdit ? t("profile.buttons.save") : t("profile.buttons.edit")}
-            </Button>
-
+            <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-md opacity-0 group-hover:opacity-100 transition"></div>
           </div>
 
-        </section>
-      )
+          {/* USERNAME */}
+          {isEdit ? (
+            <Input
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              className="text-center"
+            />
+          ) : (
+            <h1 className="text-2xl font-bold tracking-wide">
+              {user.username}
+            </h1>
+          )}
+        </div>
+
+        {/* STATS */}
+        <div className="mt-8 grid grid-cols-2 gap-4 text-center">
+          {[
+            { label: t("profile.stats.wins"), value: user.wins },
+            { label: t("profile.stats.losses"), value: user.losses },
+          ].map((stat, i) => (
+            <div
+              key={i}
+              className="bg-white/5 rounded-lg py-4 border border-white/10 hover:scale-105 transition"
+            >
+              <p className="text-xs text-white/50">{stat.label}</p>
+
+              <p className="font-bold text-lg">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* WINRATE */}
+        <Winrate wins={user.wins} losses={user.losses} draws={user.draws} />
+
+        {/* Level */}
+        <LevelProgress xp={user.xp} />
+
+        {/* BIO */}
+        <div className="mt-8">
+          <p className="text-white/50 text-sm mb-2">{t("profile.bio")}</p>
+
+          {isEdit ? (
+            <textarea
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              className="w-full bg-transparent border border-white/20 rounded px-3 py-2 focus:outline-none focus:border-cyan-400 transition resize-none"
+              rows={3}
+            />
+          ) : (
+            <p className="text-sm leading-relaxed text-white/80">{user.bio}</p>
+          )}
+        </div>
+        {/* 2FA */}
+        <div className="mt-8">
+          <p className="text-white/50 text-sm mb-2">
+            Two-Factor Authentication
+          </p>
+
+          {user.isTwoFactorEnabled ? (
+            <div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
+              <p className="text-sm text-green-400 font-medium">
+                2FA is enabled on your account.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <Button
+                type="button"
+                onClick={handleEnableTwoFactor}
+                disabled={isTwoFactorLoading}
+                className="w-full"
+              >
+                {isTwoFactorLoading ? "Loading..." : "Enable 2FA"}
+              </Button>
+
+              {qrCodeDataUrl && (
+                <div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10 space-y-4">
+                  <img
+                    src={qrCodeDataUrl}
+                    alt="2FA QR code"
+                    className="mx-auto rounded-lg bg-white p-2"
+                  />
+
+                  <Input
+                    value={twoFactorCode}
+                    onChange={(e) => setTwoFactorCode(e.target.value)}
+                    placeholder="Enter 6-digit code"
+                    maxLength={6}
+                  />
+
+                  <Button
+                    type="button"
+                    onClick={handleVerifyTwoFactor}
+                    disabled={isTwoFactorLoading || twoFactorCode.length !== 6}
+                    className="w-full"
+                  >
+                    {isTwoFactorLoading ? "Verifying..." : "Verify 2FA"}
+                  </Button>
+
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={handleEnableTwoFactor}
+                    disabled={isTwoFactorLoading}
+                    className="w-full"
+                  >
+                    Regenerate QR
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* BUTTON */}
+        <Button onClick={handleSave} className="mt-8">
+          {isEdit ? t("profile.buttons.save") : t("profile.buttons.edit")}
+        </Button>
+      </div>
+    </section>
+  );
 }

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -1,5 +1,5 @@
 import { api } from "@/services/api";
-import type { LivesGamesResponse } from "@/type/game.types";
+import type { LiveGamesResponse } from "@/type/game.types";
 
 export async function createGame() {
   const response = await api.post<{ gameId: string }>("game/create");
@@ -7,7 +7,7 @@ export async function createGame() {
 }
 
 export async function getLiveGames() {
-  const response = await api.get<LivesGamesResponse>("game/liveGames");
+  const response = await api.get<LiveGamesResponse>("game/liveGames");
   return response.data;
 }
 

--- a/frontend/src/services/gameApi.ts
+++ b/frontend/src/services/gameApi.ts
@@ -1,10 +1,17 @@
 import { api } from "@/services/api";
+import type { LivesGamesResponse } from "@/type/game.types";
 
 export async function createGame() {
   const response = await api.post<{ gameId: string }>("game/create");
   return response.data;
 }
 
+export async function getLiveGames() {
+  const response = await api.get<LivesGamesResponse>("game/liveGames");
+  return response.data;
+}
+
 export const gameApi = {
   createGame,
+  getLiveGames,
 };

--- a/frontend/src/type/game.types.ts
+++ b/frontend/src/type/game.types.ts
@@ -66,9 +66,9 @@ export interface PlayingGame {
   playerO: PublicPlayerProfile | null;
 }
 
-export interface LivesGamesResponse {
-  waiting: WaitingGame;
-  playing: PlayingGame;
+export interface LiveGamesResponse {
+  waiting: WaitingGame[];
+  playing: PlayingGame[];
 }
 
 export interface GameState {

--- a/frontend/src/type/game.types.ts
+++ b/frontend/src/type/game.types.ts
@@ -55,6 +55,22 @@ export interface ScoreBoard {
   D: number;
 }
 
+export interface WaitingGame {
+  gameId: string;
+  playerX: PublicPlayerProfile | null;
+}
+
+export interface PlayingGame {
+  gameId: string;
+  playerX: PublicPlayerProfile | null;
+  playerO: PublicPlayerProfile | null;
+}
+
+export interface LivesGamesResponse {
+  waiting: WaitingGame;
+  playing: PlayingGame;
+}
+
 export interface GameState {
   board: CellValue[][];
   currentPlayer: PlayerSymbol;

--- a/frontend/src/type/game.types.ts
+++ b/frontend/src/type/game.types.ts
@@ -12,6 +12,8 @@ export type MovesGameHistory = number[];
 
 export type SpectatorsCnt = number;
 
+export type PlayerLeft = "X" | "O" | null;
+
 export interface PublicPlayerProfile {
   id: number;
   username: string;
@@ -32,10 +34,14 @@ export interface Move extends BoardPosition {
   player: PlayerSymbol;
 }
 
+export interface PlayerSeat {
+  ownerUserId: number | null;
+  socketId: string | null;
+}
 // to stock socketId of client x and client o
 export interface PlayersInGame {
-  X: string | null;
-  O: string | null;
+  X: PlayerSeat;
+  O: PlayerSeat;
 }
 
 export interface ReplayState {
@@ -67,4 +73,5 @@ export interface GameState {
   playerProfiles: PlayerProfilesInGame;
   movesGameHistory: MovesGameHistory;
   spectatCnt: SpectatorsCnt;
+  playerLeft: PlayerLeft;
 }


### PR DESCRIPTION

## Summary

This PR adds a simple **Live Games lobby** on `/game`.

The lobby shows:
- games waiting for an opponent
- games already in progress
- a button to join a waiting game
- a button to watch a live game

This PR also improves the remote game UX with waiting screen, invite link, leave game, opponent disconnect/reconnect notifications, and replay disabled when the opponent left.

It also restores the user match history endpoint that was lost after a previous revert.

Closes #

## What was done

### Live Games lobby

- [x] Added backend endpoint `GET /game/liveGames`
- [x] Added `waiting` and `playing` game lists
- [x] Added player profiles in the live games response
- [x] Added frontend live games types
- [x] Added `gameApi.getLiveGames()`
- [x] Added `liveGamesStore` with Zustand
- [x] Added `LiveGames` page
- [x] Changed `/game` route to display the lobby
- [x] Added Join button for waiting games
- [x] Added Watch button for live games

### Remote game UX

- [x] Added waiting screen when player X is alone
- [x] Added invite link copy button
- [x] Added leave game button
- [x] Added WebSocket `leave_game` handler
- [x] Added opponent left notification
- [x] Added opponent disconnect/reconnect notifications
- [x] Disabled replay when the opponent left

### Revert recovery

- [x] Restored `GET /users/:id/history`
- [x] Fixed profile history fetching that depends on this endpoint

## Frontend limitation

The frontend lobby is still simple for now.

It mainly:
- fetches live games
- separates waiting and playing games
- displays basic cards
- allows Join / Watch navigation

It does not include auto-refresh, filters, search, pagination, or polished UI states yet.  
This can be improved later after the backend flow is stable.

## How to test

### 1. Build / launch

```bash
make prod
````

or in dev:

```bash
docker compose up --build
```

### 2. Test lobby flow

* [x] Open `/game`
* [x] Check that the Live Games page is displayed
* [x] Create a game from the normal game creation flow
* [x] Check that player X sees the waiting screen
* [x] Open `/game` in another browser/private window
* [x] Check that the game appears in **Open games**
* [x] Click **Join**
* [x] Check that the game starts
* [x] Open `/game` in a third browser/private window
* [x] Check that the game appears in **Live games**
* [x] Click **Watch**
* [x] Check that the user joins as spectator

### 3. Test leave / disconnect

* [x] Click **Leave Game**
* [x] Check that the other player gets a notification
* [x] Check that replay is disabled if the opponent left
* [x] Close one player tab during a game
* [x] Check that the other player sees the disconnect warning
* [x] Reopen the game
* [x] Check that reconnect notification appears

### 4. Test history

* [x] Finish a game
* [x] Go to `/profile`
* [x] Check that match history is displayed

## API endpoints to verify

### `GET /game/liveGames`

Purpose: returns active games separated between waiting and playing.

Example response:

```json
{
  "waiting": [
    {
      "gameId": "example-game-id",
      "playerX": {
        "id": 1,
        "username": "PlayerOne",
        "avatar": null
      }
    }
  ],
  "playing": [
    {
      "gameId": "example-game-id-2",
      "playerX": {
        "id": 1,
        "username": "PlayerX",
        "avatar": null
      },
      "playerO": {
        "id": 2,
        "username": "PlayerO",
        "avatar": null
      }
    }
  ]
}
```

### `GET /users/:id/history`

Purpose: returns finished game history for one user.

Example response:

```json
[
  {
    "id": "match-id",
    "winnerId": 1,
    "status": "finished",
    "createdAt": "2026-04-26T10:00:00.000Z"
  }
]
```

The exact response can be different depending on the current backend model.

## Flow

### Lobby flow

```mermaid
flowchart TD
    A["User opens /game"] --> B["LiveGames page"]
    B --> C["Fetch GET /game/liveGames"]
    C --> D{"Game status"}
    D -->|waiting| E["Show in Open games"]
    D -->|playing| F["Show in Live games"]
    E --> G["Join button"]
    F --> H["Watch button"]
    G --> I["/game/:gameId"]
    H --> I
```

### Leave game flow

```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant Socket
    participant Backend
    participant OtherPlayer

    User->>Frontend: Click Leave Game
    Frontend->>Socket: emit leave_game
    Socket->>Backend: leave_game received
    Backend->>Backend: update playerLeft
    Backend->>OtherPlayer: game_updated / notification
```

## Code example

### Backend live games response

```ts
getLiveGames() {
  const waiting = [];
  const playing = [];

  for (const [gameId, game] of this.activeGame.entries()) {
    if (game.status === 'waiting') {
      waiting.push({ gameId, playerX: game.playerProfiles.X });
    } else if (game.status === 'playing') {
      playing.push({
        gameId,
        playerX: game.playerProfiles.X,
        playerO: game.playerProfiles.O,
      });
    }
  }

  return { waiting, playing };
}
```

### Frontend navigation

```tsx
<Button onClick={() => navigate(`/game/${game.gameId}`)}>
  Join
</Button>
```

## Revert recovery note

A previous revert removed some code related to `game` and `history`.

This branch restores the important part that was blocking the profile history:

* `GET /users/:id/history` in `users.controller.ts`
* profile history fetching that depends on this endpoint

Some game/history behavior should still be checked manually after merge to avoid hidden regressions.

## Testing

* [x] `make prod` successful
* [x] Frontend tested locally
* [x] Backend tested locally
* [x] Integration tested manually
* [x] Swagger/API endpoints checked

## Checklist

* [x] Target branch is `dev`
* [x] No `.env` or sensitive files committed
* [x] Code follows project conventions
* [x] No database migration needed

Closes #188
Closes #189
Closes #190
Closes #191
Closes #181
Closes #119