### PR TITLE
[AUTH][OAUTH] Fix 42 username generation

### DIFF
--- a/backend/src/auth/oauth.service.ts
+++ b/backend/src/auth/oauth.service.ts
@@ -4,10 +4,11 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 
 export interface OAuthProfile {
-	provider: 'google' | '42';
+	provider: '42' | 'google' ;
 	providerUserId: string;
 	email: string;
 	displayName: string;
+	providerUsername?: string;
 	avatarUrl: string;
 }
 
@@ -200,6 +201,7 @@ export class OAuthService {
 			providerUserId: String(fortyTwoUser.id),
 			email: fortyTwoUser.email,
 			displayName: fortyTwoUser.displayname,
+			providerUsername: fortyTwoUser.login,
 			avatarUrl:
 				fortyTwoUser.image?.versions?.medium ??
 				fortyTwoUser.image?.link ??

--- a/backend/src/auth/oauth.service.ts
+++ b/backend/src/auth/oauth.service.ts
@@ -56,6 +56,29 @@ export class OAuthService {
 		private readonly httpService: HttpService,
 	) {}
 
+		private normalizeUsername(value: string) {
+		return value
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9_]/g, '_')
+			.replace(/_+/g, '_')
+			.replace(/^_+|_+$/g, '');
+	}
+
+	private async generateUniqueUsername(baseUsername: string) {
+		const cleanBaseUsername = this.normalizeUsername(baseUsername) || 'user';
+
+		let candidate = cleanBaseUsername;
+		let suffix = 1;
+
+		while (await this.prisma.user.findUnique({ where: { username: candidate } })) {
+			candidate = `${cleanBaseUsername}_${suffix}`;
+			suffix++;
+		}
+
+		return candidate;
+	}
+
 	private async findOrCreateUserFromOAuthProfile(profile: OAuthProfile) {
 		const existingOAuthAccount = await this.prisma.oAuthAccount.findUnique({
 			where: {

--- a/backend/src/auth/oauth.service.ts
+++ b/backend/src/auth/oauth.service.ts
@@ -138,8 +138,8 @@ export class OAuthService {
 			};
 		}
 
-		const baseUsername = profile.displayName.toLowerCase().replace(/\s+/g, '_');
-		const username = `${baseUsername}_${Date.now()}`;
+		const baseUsername = profile.providerUsername ?? profile.displayName;
+		const username = await this.generateUniqueUsername(baseUsername);
 
 		const user = await this.prisma.user.create({
 			data: {


### PR DESCRIPTION
## Summary

This PR improves OAuth username generation for 42 login.

Previously, new OAuth users received usernames based on `displayName` plus a timestamp, for example:

john_doe_171245124124

Now, 42 users receive cleaner usernames based on the 42 `login` field.

Example:

jdoe

If the username already exists, the backend generates a clean suffix:

jdoe_1

## What was changed

- Added optional `providerUsername` to the normalized OAuth profile
- Passed the 42 `login` field into the OAuth profile
- Added username normalization helper
- Added unique username generation helper
- Replaced timestamp-based username generation

## Behavior

- OAuth linking still uses `provider + providerUserId`
- Existing linked OAuth users continue to work
- New 42 OAuth users get clean usernames
- Username collisions are handled safely with suffixes

## Tests

- Ran a clean setup:
  - `make nuke`
  - `make setup`
  - added the required secrets
  - started the project with  `make up`  / production *(Blocked until seed fixed)* setup if needed

- Created a normal user manually with the same username as my 42 login.

- Opened Prisma Studio with `make prisma`:
  - verified that the normal user was created correctly
  - verified that the username matched my 42 login

- Logged in with OAuth 42.

- Verified in Prisma Studio that:
  - a new OAuth user was created
  - the OAuth user username used my 42 login with `_1` added
  - this avoided a username conflict with the existing normal user
  - the provider is stored correctly
  - the provider user ID is stored correctly
  - the OAuth account is linked to the correct user ID

- Logged in again with OAuth 42 and verified that:
  - no duplicate user was created
  - the existing OAuthAccount link was reused correctly
  - OAuth login still works as expected

## Notes

This PR only fixes OAuth username generation.

Closes #237 