### PR TITLE
[BACKEND][USERS] Secure user API and profile updates

### DIFF
--- a/backend/src/auth/dto/login.dto.ts
+++ b/backend/src/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, Matches, MinLength } from 'class-validator';
 
 export class LoginDto {
 		@ApiProperty({
@@ -10,11 +10,14 @@ export class LoginDto {
 		email: string;
 
 		@ApiProperty({
-				example: 'secret123',
-				description: 'User password',
-				minLength: 6,
+			example: 'Secret123',
+			description: 'User password',
+			minLength: 8,
 		})
 		@IsString()
-		@MinLength(6)
+		@MinLength(8)
+		@Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
+			message: 'password must contain at least one lowercase letter, one uppercase letter, and one number',
+		})
 		password: string;
 }

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsOptional, IsString, Matches, MinLength } from 'class-validator';
 
 export class RegisterDto {
 		@ApiProperty({
@@ -10,12 +10,15 @@ export class RegisterDto {
 		email: string;
 
 		@ApiProperty({
-				example: 'secret123',
-				description: 'User password',
-				minLength: 6,
+			example: 'Secret123',
+			description: 'User password',
+			minLength: 8,
 		})
 		@IsString()
-		@MinLength(6)
+		@MinLength(8)
+		@Matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/, {
+			message: 'password must contain at least one lowercase letter, one uppercase letter, and one number',
+		})
 		password: string;
 
 		@ApiProperty({

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -27,7 +27,7 @@ export class RegisterDto {
 		username: string;
 
 		@ApiPropertyOptional({
-				example: 'I like Pong and backend development.',
+				example: 'I like to play Tic-tac-toe and backend development.',
 				description: 'Optional user biography',
 		})
 		@IsOptional()

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,10 +5,11 @@ import {
 	Body,
 	Get,
 	Patch,
-	UseGuards,
 	Query,
 	Inject,
 	forwardRef,
+	Req,
+	ForbiddenException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -54,9 +55,13 @@ export class UsersController {
 	@ApiOperation({ summary: 'Update user' })
 	@Patch(':id')
 	updateUser(
-	@Param('id', ParseIntPipe) id: number,
-	@Body() updateUserDto: UpdateUserDto,
+		@Param('id', ParseIntPipe) id: number,
+		@Body() updateUserDto: UpdateUserDto,
+		@Req() req,
 	) {
+		if (req.user.sub !== id) {
+			throw new ForbiddenException('You can only update your own profile');
+		}
 		return this.usersService.updateUser(id, updateUserDto);
 	}
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -9,15 +9,15 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 // import { CreateUserDto } from './dto/create-user.dto';
 
-const safeUserSelect = {
+const publicUserSelect = {
 	id: true,
-	email: true,
 	username: true,
 	bio: true,
 	avatar: true,
 	wins: true,
 	losses: true,
 	draws: true,
+	xp: true,
 };
 
 @Injectable()
@@ -26,14 +26,14 @@ export class UsersService {
 
 	async getUsers() {
 		return this.prisma.user.findMany({
-			select: safeUserSelect,
+			select: publicUserSelect,
 		});
 	}
 
 	async getUser(id: number) {
 		const user = await this.prisma.user.findUnique({
 			where: { id },
-			select: safeUserSelect,
+			select: publicUserSelect,
 		});
 
 		if (!user) {
@@ -57,7 +57,7 @@ export class UsersService {
 			return await this.prisma.user.update({
 				where: { id },
 				data: updateUserDto,
-				select: safeUserSelect,
+				select: publicUserSelect,
 			});
 		} catch (error) {
 			if (

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -24,23 +24,33 @@ const publicUserSelect = {
 export class UsersService {
 	constructor(private prisma: PrismaService) {}
 
+	private toPublicUser(user: any) {
+	return {
+		id: user.id,
+		username: user.username,
+		bio: user.bio,
+		avatar: user.avatar,
+		wins: user.wins,
+		losses: user.losses,
+		draws: user.draws,
+		xp: user.xp,
+	};
+}
+
 	async getUsers() {
-		return this.prisma.user.findMany({
-			select: publicUserSelect,
-		});
+		const users = await this.prisma.user.findMany();
+		return users.map(user => this.toPublicUser(user));
 	}
 
 	async getUser(id: number) {
 		const user = await this.prisma.user.findUnique({
 			where: { id },
-			select: publicUserSelect,
 		});
 
-		if (!user) {
+		if (!user)
 			throw new NotFoundException('User not found');
-		}
 
-		return user;
+		return this.toPublicUser(user);
 	}
 
 	async updateUser(id: number, updateUserDto: UpdateUserDto) {
@@ -54,11 +64,12 @@ export class UsersService {
 		}
 
 		try {
-			return await this.prisma.user.update({
+			const updatedUser = await this.prisma.user.update({
 				where: { id },
 				data: updateUserDto,
-				select: publicUserSelect,
 			});
+
+			return this.toPublicUser(updatedUser);
 		} catch (error) {
 			if (
 				error instanceof Prisma.PrismaClientKnownRequestError &&


### PR DESCRIPTION
## Summary

This PR secures user-related endpoints and improves authentication rules.

## What was done

### User API security

* Removed `email` from public user responses
* Introduced a mapping layer (`toPublicUser`)
* Ensured `/users` only returns safe public profile data

### Authorization

* Restricted `PATCH /users/:id` so users can only update their own profile
* Added check using JWT payload (`req.user.sub`)

### Password security

* Enforced stronger password rules:

  * minimum 8 characters
  * at least one lowercase letter
  * at least one uppercase letter
  * at least one number
* Applied validation to both register and login DTOs

## Behavior

* `/users` no longer leaks sensitive data
* Users cannot modify other users’ profiles
* Weak passwords are rejected at registration and login

## Limitations

* Updating `email` is currently not allowed
* This will be handled in a future PR with a proper secure flow

## Tests

* Verified `/users` no longer returns email
* Verified `/users/:id` returns only public fields
* Verified `PATCH /users/:id`:

  * works for own user
  * returns 403 for other users
* Tested password validation:

  * weak password → rejected
  * strong password → accepted
* Tested login with valid credentials

### Swagger testing

* Used Swagger (`/api/api-docs`) to test endpoints
* Modified request bodies directly in Swagger before execution
* Observed responses and status codes to validate behavior

## Notes

Email update and related account changes will be handled in a separate PR.

Closes #239 
