### PR TITLE
[BACKEND][USERS] Add typed user mapping and safer user queries

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -25,6 +26,23 @@ export type LoginResult =
 	| FullAuthLoginResult
 	| TwoFactorRequiredLoginResult;
 
+const privateUserSelect = {
+	id: true,
+	email: true,
+	username: true,
+	bio: true,
+	avatar: true,
+	wins: true,
+	losses: true,
+	draws: true,
+	xp: true,
+	isTwoFactorEnabled: true,
+} satisfies Prisma.UserSelect;
+
+type PrivateUser = Prisma.UserGetPayload<{
+	select: typeof privateUserSelect;
+}>;
+
 @Injectable()
 export class AuthService {
 	constructor(
@@ -33,7 +51,7 @@ export class AuthService {
 		private readonly twoFactorService: TwoFactorService,
 	) {}
 
-	private toPrivateUser(user: any) {
+	private toPrivateUser(user: PrivateUser) {
 	return {
 		id: user.id,
 		email: user.email,
@@ -63,6 +81,7 @@ export class AuthService {
 				losses: 0,
 				draws: 0,
 			},
+			select: privateUserSelect,
 		});
 
 		return this.toPrivateUser(user);
@@ -138,6 +157,7 @@ export class AuthService {
 	async me(userId: number) {
 		const user = await this.prisma.user.findUnique({
 			where: { id: userId },
+			select: privateUserSelect,
 			});
 
 		if (!user) {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -33,6 +33,21 @@ export class AuthService {
 		private readonly twoFactorService: TwoFactorService,
 	) {}
 
+	private toPrivateUser(user: any) {
+	return {
+		id: user.id,
+		email: user.email,
+		username: user.username,
+		bio: user.bio,
+		avatar: user.avatar,
+		wins: user.wins,
+		losses: user.losses,
+		draws: user.draws,
+		xp: user.xp,
+		isTwoFactorEnabled: user.isTwoFactorEnabled,
+		};
+	}
+
 	async register(registerDto: RegisterDto) {
 		const passwordHash = await bcrypt.hash(registerDto.password, 10);
 
@@ -50,18 +65,7 @@ export class AuthService {
 			},
 		});
 
-		return {
-			id: user.id,
-			email: user.email,
-			username: user.username,
-			bio: user.bio,
-			avatar: user.avatar,
-			wins: user.wins,
-			losses: user.losses,
-			draws: user.draws,
-			xp: user.xp,
-			isTwoFactorEnabled: user.isTwoFactorEnabled,
-			};
+		return this.toPrivateUser(user);
 		} catch (error: unknown) {
 			if (
 				typeof error === 'object' &&
@@ -140,17 +144,6 @@ export class AuthService {
 			throw new NotFoundException('User not found');
 			}
 
-		return {
-			id: user.id,
-			email: user.email,
-			username: user.username,
-			bio: user.bio,
-			avatar: user.avatar,
-			wins: user.wins,
-			losses: user.losses,
-			draws: user.draws,
-			xp: user.xp,
-			isTwoFactorEnabled: user.isTwoFactorEnabled,
-			};
+		return this.toPrivateUser(user);
 	}
 }

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -135,7 +135,7 @@ export class MatchesService {
 			},
 		orderBy: {
 			date: 'desc',
-		},
+			},
 		});
 
     const getUserInfoFromGame = game.map((m) => {

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -114,29 +114,29 @@ export class MatchesService {
     }
   }
 
-  async getFinishedGamesHistory(userId: number) {
-    const game = await this.prismaService.game.findMany({
-      where: {
-        OR: [{ player1Id: userId }, { player2Id: userId }],
-      },
-      include: {
-			player1: {
-				select: {
-					username: true,
-					avatar: true,
-				},
-			},
-			player2: {
-				select: {
-					username: true,
-					avatar: true,
-				},
-			},
+	async getFinishedGamesHistory(userId: number) {
+		const game = await this.prismaService.game.findMany({
+		where: {
+			OR: [{ player1Id: userId }, { player2Id: userId }],
 		},
-      orderBy: {
-        date: 'desc',
-      },
-    });
+		include: {
+				player1: {
+					select: {
+						username: true,
+						avatar: true,
+					},
+				},
+				player2: {
+					select: {
+						username: true,
+						avatar: true,
+					},
+				},
+			},
+		orderBy: {
+			date: 'desc',
+		},
+		});
 
     const getUserInfoFromGame = game.map((m) => {
       const isPLayer1 = m.player1Id === userId;

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -120,10 +120,19 @@ export class MatchesService {
         OR: [{ player1Id: userId }, { player2Id: userId }],
       },
       include: {
-        player1: true,
-        player2: true,
-        winner: true,
-      },
+			player1: {
+				select: {
+					username: true,
+					avatar: true,
+				},
+			},
+			player2: {
+				select: {
+					username: true,
+					avatar: true,
+				},
+			},
+		},
       orderBy: {
         date: 'desc',
       },

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -40,11 +40,14 @@ export class UsersController {
     return this.matchServices.getGameLeaderboard(safeSortBy);
   }
 
-  @ApiOperation({ summary: 'Get all users' })
-  @Get()
-  getUsers() {
-    return this.usersService.getUsers();
-  }
+	@ApiOperation({ summary: 'Get all users' })
+	@Get()
+	getUsers(
+		@Query('limit') limit?: string,
+		@Query('offset') offset?: string,
+	) {
+		return this.usersService.getUsers(limit, offset);
+	}
 
   @ApiOperation({ summary: 'Get user by ID' })
   @Get(':id')

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -41,10 +41,16 @@ export class UsersService {
 	};
 }
 
-	async getUsers() {
+	async getUsers(limit?: string, offset?: string) {
+		const parsedLimit = Math.min(Number(limit) || 20, 100);
+		const parsedOffset = Number(offset) || 0;
+
 		const users = await this.prisma.user.findMany({
 			select: publicUserSelect,
+			take: parsedLimit,
+			skip: parsedOffset,
 		});
+
 		return users.map(user => this.toPublicUser(user));
 	}
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -18,13 +18,17 @@ const publicUserSelect = {
 	losses: true,
 	draws: true,
 	xp: true,
-};
+} satisfies Prisma.UserSelect;
+
+type PublicUser = Prisma.UserGetPayload<{
+	select: typeof publicUserSelect;
+}>;
 
 @Injectable()
 export class UsersService {
 	constructor(private prisma: PrismaService) {}
 
-	private toPublicUser(user: any) {
+	private toPublicUser(user: PublicUser) {
 	return {
 		id: user.id,
 		username: user.username,
@@ -38,13 +42,16 @@ export class UsersService {
 }
 
 	async getUsers() {
-		const users = await this.prisma.user.findMany();
+		const users = await this.prisma.user.findMany({
+			select: publicUserSelect,
+		});
 		return users.map(user => this.toPublicUser(user));
 	}
 
 	async getUser(id: number) {
 		const user = await this.prisma.user.findUnique({
 			where: { id },
+			select: publicUserSelect,
 		});
 
 		if (!user)


### PR DESCRIPTION
## Summary

This PR improves the backend user API architecture by adding typed user response mapping, limiting Prisma queries to the fields actually needed, and adding simple pagination to the users endpoint.

## What was done

- Added typed public user response mapping in `UsersService`
- Added typed private user response mapping in `AuthService`
- Updated public user queries to use Prisma `select`
- Updated `/auth/me` and register responses to use a private user mapper
- Narrowed match history user relation queries to avoid loading full related users
- Added `limit` and `offset` pagination to `GET /users`

## Match history note

I changed the match history query to avoid loading full related User objects.

The API response was already safe because it only returned opponent username and avatar, but Prisma was still fetching complete player objects internally through `player1: true`, `player2: true`, and `winner: true`.

The fix keeps the response exactly the same while limiting related users to only the fields needed for history display.

I removed `winner` from the include because the service only uses the scalar `winnerId`, not the related `winner` user object.

## Tests (you can test using Swagger directly or adding /api/... to your URL)

- Tested `GET /api/users`
- Tested `GET /api/users?limit=2`
- Tested `GET /api/users?limit=2&offset=2`
- Tested `GET /api/users/:id`
- Tested `GET /api/auth/me`
- Tested `POST /api/auth/register`
- Tested `GET /api/users/:id/history`
- Confirmed public user responses do not expose email, password hash, or 2FA secrets
- Confirmed private auth response includes email and `isTwoFactorEnabled`, but not password hash or 2FA secrets
- Confirmed match history response shape stays unchanged

## Future work

- Add response DTOs or shared mapper utilities if more services need user response mapping
- Add stronger query parameter validation with DTOs
- Design a separate safe email update flow
- Add rate limiting later

Closes #243 