### PR TITLE
[BACKEND][AUTH] Extend session lifetime for stable gameplay

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -85,7 +85,7 @@ export class AuthController {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
-			maxAge: 60 * 60 * 1000,
+			maxAge: 8 * 60 * 60 * 1000,
 			path: '/',
 		});
 
@@ -225,7 +225,7 @@ export class AuthController {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
-			maxAge: 60 * 60 * 1000,
+			maxAge: 8 * 60 * 60 * 1000,
 			path: '/',
 		});
 

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -13,7 +13,7 @@ import { TwoFactorService } from './twofa.service';
 	imports: [
 		JwtModule.register({
 			secret: process.env.JWT_SECRET,
-			signOptions: { expiresIn: '1h' },
+			signOptions: { expiresIn: '8h' },
 		}),
 		PrismaModule,
 		HttpModule,

--- a/backend/src/auth/oauth.controller.ts
+++ b/backend/src/auth/oauth.controller.ts
@@ -117,7 +117,7 @@ export class OAuthController {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === 'production',
 				sameSite: 'lax',
-				maxAge: 60 * 60 * 1000,
+				maxAge: 8 * 60 * 60 * 1000,
 			});
 
 			res?.clearCookie('2fa_pending', {
@@ -197,7 +197,7 @@ export class OAuthController {
 				httpOnly: true,
 				secure: process.env.NODE_ENV === 'production',
 				sameSite: 'lax',
-				maxAge: 60 * 60 * 1000,
+				maxAge: 8 * 60 * 60 * 1000,
 			});
 
 			res?.clearCookie('2fa_pending', {


### PR DESCRIPTION
## Summary

This PR extends the `access_token` lifetime to improve stability during gameplay sessions.

Previously, the token expired after 1 hour, which could disconnect users during active matches.  
This change increases the lifetime to 8 hours as a practical solution for Sprint 6.

Closes #246

---

## What was done

- Updated JWT expiration:
  - `expiresIn: '1h'` → `expiresIn: '8h'`
- Updated cookie lifetime:
  - `maxAge: 60 * 60 * 1000` → `maxAge: 8 * 60 * 60 * 1000`
- Applied changes consistently to:
  - `auth.controller.ts`
  - `oauth.controller.ts`
  - `auth.module.ts`

- Left `2fa_pending` unchanged:
  - `expiresIn: '5m'`
  - `maxAge: 5 * 60 * 1000`

---

## Reasoning

- `access_token` represents full authentication and should remain valid during normal gameplay sessions.
- Increasing it to 8 hours reduces unexpected disconnections during matches and demos.
- `2fa_pending` remains short-lived because it represents a temporary partial-authentication state.

---

## Tests

### Functional tests

- `POST /api/auth/login` → login works
- `GET /api/auth/me` → authenticated request works
- `POST /api/auth/logout` → cookie is cleared correctly
- OAuth login flow tested and working

### Cookie validation

- Open browser DevTools (F12)
- Go to **Application → Cookies**
- Inspect `access_token`
- Check the expiration timestamp
- Compare it with current time → ~8 hours in the future

---

## Future work

A full refresh-token system was considered but intentionally not implemented in this PR.

Reason:

- Requires:
  - refresh token storage (DB or rotation logic)
  - `/auth/refresh` endpoint
  - token rotation and invalidation strategy
  - integration with 2FA and OAuth flows
  - WebSocket re-authentication handling

- This is a larger authentication feature and should be handled in a dedicated PR.

For the current project stage, extending the session lifetime is a simpler and sufficient solution.

---

## Notes

- This change does not weaken security significantly, as the lifetime is increased moderately (8h instead of 24h).
- Maintains a good balance between usability (stable sessions) and security.