### PR TITLE
[BACK-FRONT] Track Total Games Played — Leaderboard

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -23,7 +23,6 @@ model User {
   draws               Int            @default(0)
   xp                  Int            @default(0)
   totalGames          Int            @default(0)
-  winrate             Float          @default(0)
   isTwoFactorEnabled  Boolean        @default(false)
   twoFactorSecret     String?
   twoFactorTempSecret String?

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,6 +22,8 @@ model User {
   losses              Int            @default(0)
   draws               Int            @default(0)
   xp                  Int            @default(0)
+  totalGames          Int            @default(0)
+  winrate             Float          @default(0)
   isTwoFactorEnabled  Boolean        @default(false)
   twoFactorSecret     String?
   twoFactorTempSecret String?

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -112,7 +112,7 @@ async function main() {
 
     // ── XP & Update User ──────────────────────
     const xp = wins * 20 + draws * 10 + losses * 5;
-    await prisma.user.update({ where: { id: user.id }, data: { wins, losses, draws, xp } });
+    await prisma.user.update({ where: { id: user.id }, data: { wins, losses, draws, xp, totalGames: total } });
   }
   console.log('\x1b[32m✓ Updated Users\' XP and Stats\x1b[0m');
 }

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -60,6 +60,7 @@ export class MatchesService {
             data: {
               wins: { increment: 1 },
               xp: { increment: 20 },
+              totalGames: { increment: 1 },
             },
           });
 
@@ -68,6 +69,7 @@ export class MatchesService {
             data: {
               losses: { increment: 1 },
               xp: { increment: 5 },
+              totalGames: { increment: 1 },
             },
           });
         } else if (result.winnerId === result.player2Id) {
@@ -76,6 +78,7 @@ export class MatchesService {
             data: {
               wins: { increment: 1 },
               xp: { increment: 20 },
+              totalGames: { increment: 1 },
             },
           });
 
@@ -84,6 +87,7 @@ export class MatchesService {
             data: {
               losses: { increment: 1 },
               xp: { increment: 5 },
+              totalGames: { increment: 1 },
             },
           });
         } else {
@@ -92,6 +96,7 @@ export class MatchesService {
             data: {
               draws: { increment: 1 },
               xp: { increment: 10 },
+              totalGames: { increment: 1 },
             },
           });
 
@@ -100,6 +105,7 @@ export class MatchesService {
             data: {
               draws: { increment: 1 },
               xp: { increment: 10 },
+              totalGames: { increment: 1 },
             },
           });
         }
@@ -178,6 +184,8 @@ export class MatchesService {
       orderBy = { wins: 'desc' };
     } else if (sortBy === 'xp') {
       orderBy = { xp: 'desc' };
+    } else if (sortBy === 'totalGames') {
+      orderBy = { totalGames: 'desc' };
     } else {
       orderBy = { wins: 'desc' };
     }
@@ -193,6 +201,7 @@ export class MatchesService {
         username: m.username,
         xp: m.xp,
         wins: m.wins,
+        totalGames: m.totalGames,
       };
     });
     return getUserInfo;

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -172,7 +172,7 @@ export class MatchesService {
     return getUserInfoFromGame;
   }
 
-  async getGameLeaderboard(sortBy: 'wins' | 'xp') {
+  async getGameLeaderboard(sortBy: 'wins' | 'xp' | 'winrate' | 'totalGames') {
     let orderBy;
     if (sortBy === 'wins') {
       orderBy = { wins: 'desc' };

--- a/backend/src/modules/game/matches.service.ts
+++ b/backend/src/modules/game/matches.service.ts
@@ -178,7 +178,7 @@ export class MatchesService {
     return getUserInfoFromGame;
   }
 
-  async getGameLeaderboard(sortBy: 'wins' | 'xp' | 'winrate' | 'totalGames') {
+  async getGameLeaderboard(sortBy: 'wins' | 'xp' | 'totalGames') {
     let orderBy;
     if (sortBy === 'wins') {
       orderBy = { wins: 'desc' };

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -17,6 +17,8 @@ import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MatchesService } from 'src/modules/game/matches.service';
 import { AchievementsService } from 'src/modules/game/achievement/achievements.service';
 
+type SortBy = 'xp' | 'wins' | 'winrate' | 'totalGames';
+
 @ApiTags('Users')
 @Controller('users')
 export class UsersController {
@@ -35,8 +37,10 @@ export class UsersController {
 
   @ApiOperation({ summary: 'Get leaderboard of users' })
   @Get('leaderboard')
-  getLeaderboard(@Query('sortBy') sortBy: string) {
-    const safeSortBy = sortBy === 'xp' ? 'xp' : 'wins';
+  getLeaderboard(@Query('sortBy') sortBy?: SortBy) {
+    const allowedSorts: SortBy[] = ['xp', 'wins', 'winrate', 'totalGames'];
+
+    const safeSortBy: SortBy = sortBy && allowedSorts.includes(sortBy) ? sortBy : 'xp';
     return this.matchServices.getGameLeaderboard(safeSortBy);
   }
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -17,7 +17,7 @@ import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MatchesService } from 'src/modules/game/matches.service';
 import { AchievementsService } from 'src/modules/game/achievement/achievements.service';
 
-type SortBy = 'xp' | 'wins' | 'winrate' | 'totalGames';
+type SortBy = 'xp' | 'wins' | 'totalGames';
 
 @ApiTags('Users')
 @Controller('users')
@@ -38,7 +38,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Get leaderboard of users' })
   @Get('leaderboard')
   getLeaderboard(@Query('sortBy') sortBy?: SortBy) {
-    const allowedSorts: SortBy[] = ['xp', 'wins', 'winrate', 'totalGames'];
+    const allowedSorts: SortBy[] = ['xp', 'wins', 'totalGames'];
 
     const safeSortBy: SortBy = sortBy && allowedSorts.includes(sortBy) ? sortBy : 'xp';
     return this.matchServices.getGameLeaderboard(safeSortBy);

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -73,9 +73,12 @@
       "title": "Leaderboard",
       "topXP": "Highest level",
       "topWins": "Most wins",
+      "topTotalGames": "Most games played",
       "empty": "No players are listed in the rankings",
       "xp": "{{value}} XP",
-      "wins": "{{value}} Wins"
+      "wins": "{{value}} Wins",
+      "totalGames": "{{value}} Games"
+
     },
 
     "history": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -73,9 +73,11 @@
       "title": "Clasificación",
       "topXP": "Nivel más alto",
       "topWins": "Más victorias",
+      "topTotalGames": "Más partidas jugadas",
       "empty": "No hay jugadores en la clasificación",
       "xp": "{{value}} XP",
-      "wins": "{{value}} Victorias"
+      "wins": "{{value}} Victorias",
+      "totalGames": "{{value}} Partidas"
     },
 
     "history": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -73,9 +73,11 @@
         "title": "Classement",
         "topXP": "Plus haut niveau",
         "topWins": "Plus de victoires",
+        "topTotalGames": "Plus de parties jouées",
         "empty": "Aucun joueur dans le classement",
         "xp": "{{value}} XP",
-        "wins": "{{value}} Victoires"
+        "wins": "{{value}} Victoires",
+        "totalGames": "{{value}} Parties"
     },
 
     "history": {

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -9,11 +9,12 @@ interface LeaderBoard {
   username: string;
   xp: number;
   wins: number;
+  totalGames: number;
 }
 
 export default function LeaderBoard() {
   const [leaderboard, setLeaderboard] = useState<LeaderBoard[]>([]);
-  const [sortBy, setSortBy] = useState<"xp" | "wins">("wins");
+  const [sortBy, setSortBy] = useState<"xp" | "totalGames" | "wins">("wins");
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -55,6 +56,15 @@ export default function LeaderBoard() {
           >
             {t("leaderboard.topWins")}
           </Button>
+
+          <Button
+            onClick={() => setSortBy("totalGames")}
+            variant={sortBy === "totalGames"
+              ? "primary"
+              : "secondary"}
+          >
+            {t("leaderboard.topTotalGames")}
+          </Button>
         </div>
 
         {leaderboard.length === 0 ? (
@@ -82,7 +92,9 @@ export default function LeaderBoard() {
                   <p className="text-blue-400 font-bold">
                     {sortBy === "xp"
                       ? t("leaderboard.xp", { value: l.xp })
-                      : t("leaderboard.wins", { value: l.wins ?? 0 })}
+                      : sortBy === "totalGames"
+                        ? t("leaderboard.totalGames", { value: l.totalGames })
+                        : t("leaderboard.wins", { value: l.wins ?? 0 })}
                   </p>
                 </div>
               </div>

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -72,7 +72,7 @@ export async function getUserHistory(id: number) {
     return response.data
 }
 
-export async function getLeaderboard(sortBy?: "xp" | "wins" | "winrate" | "totalgames") {
+export async function getLeaderboard(sortBy?: "xp" | "wins" |  "totalGames") {
 
     const response = await api.get("users/leaderboard", { params: sortBy ? { sortBy } : {} })
     return response.data

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -72,7 +72,7 @@ export async function getUserHistory(id: number) {
     return response.data
 }
 
-export async function getLeaderboard(sortBy?: "xp" | "wins") {
+export async function getLeaderboard(sortBy?: "xp" | "wins" | "winrate" | "totalgames") {
 
     const response = await api.get("users/leaderboard", { params: sortBy ? { sortBy } : {} })
     return response.data


### PR DESCRIPTION
## Summary

Adds a `totalGames` counter to each user to enrich profile statistics and enable a new sorting mode in the leaderboard. Instead of computing game counts on the fly at query time, the counter is persisted directly in the database for optimal performance.

---

## Files modified

| File | Description |
|------|-------------|
| `prisma/schema.prisma` | Added `totalGames` field (`Int`, default `0`) to the `User` model |
| `prisma/seed.ts` | Updated seed script to retroactively compute and initialize `totalGames` for test accounts |
| `src/modules/game/matches.service.ts` | Auto-increments `totalGames` in `recordMatch` and handles dynamic leaderboard sorting |
| `src/modules/users/users.controller.ts` | Updated validation to allow sorting by `totalGames` via query params |
| `src/services/userService.ts` (Frontend) | Fixed casing (`totalGames`) and updated the response interface |
| `src/pages/LeaderBoard.tsx` (Frontend) | Added sort button and dynamic stat display (Wins / XP / Games) |

---

## What was done

The main goal was to provide a clear view of player activity while ensuring optimal leaderboard performance.

### 1. Data persistence — `totalGames`

- **Auto-increment:** In `matches.service.ts`, every match conclusion now triggers an `increment: 1` on `totalGames` for both participants inside the Prisma transaction, ensuring data integrity even on draws.

### 2. Leaderboard evolution

- **Multi-criteria sorting:** The backend now supports three sorting axes — experience (`xp`), victories (`wins`), and total activity (`totalGames`).
- **Dynamic mapping:** The match service now returns the full stats block so the frontend can display contextual data per active filter.

### 3. Frontend / backend alignment

- **Casing fix:** Strict synchronization of sort keys between the API and the client (`totalgames` → `totalGames`).
- **Adaptive UI:** The React component adjusts its labels and displayed values using nested ternaries based on the active filter.

---

## Why

- **SQL performance:** Sorting by `totalGames` is now native and instant in the database — no joins or runtime aggregations needed.
- **User engagement:** Highlights the most active players, even those without the best win ratio.

---

## How to test

### Setup

Reset your environment to apply the new schema and updated seed:

```sh
make nuke
make setup
make up
```

---

### Verify the seed

Check that dummy accounts have their stats correctly initialized:

```
http://localhost:1024/api/users/leaderboard?sortBy=totalGames
```
```
http://localhost:1024/leaderboard
```

All seeded users should appear with a non-zero `totalGames` value reflecting their match history.

---

### Test match recording

1. Connect two accounts and play a match.
2. After the match ends, verify that `totalGames` incremented by 1 for **both** players:

```
http://localhost:1024/leaderboard
```

3. Switch between the three leaderboard filters in the React UI and confirm the display updates correctly:

| Filter | Displayed stat |
|--------|---------------|
| `xp` | Experience points |
| `wins` | Total victories |
| `totalGames` | Total games played |