### PR TITLE
[BACKEND][USERS] Validate pagination and add username search

### DIFF
--- a/backend/src/users/dto/get-users-query.dto.ts
+++ b/backend/src/users/dto/get-users-query.dto.ts
@@ -6,7 +6,6 @@ export class GetUsersQueryDto {
 	@Type(() => Number)
 	@IsInt()
 	@Min(0)
-	@Max(100)
 	limit?: number;
 
 	@IsOptional()

--- a/backend/src/users/dto/get-users-query.dto.ts
+++ b/backend/src/users/dto/get-users-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsInt, Min, IsString, MaxLength } from 'class-validator';
+import { IsOptional, IsInt, Min, IsString, MaxLength, MinLength } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -26,10 +26,12 @@ export class GetUsersQueryDto {
 	@ApiPropertyOptional({
 		example: 'nico',
 		description: 'Optional case-insensitive username search.',
+		minLength: 1,
 		maxLength: 50,
 	})
 	@IsOptional()
 	@IsString()
+	@MinLength(1)
 	@MaxLength(50)
 	search?: string;
 }

--- a/backend/src/users/dto/get-users-query.dto.ts
+++ b/backend/src/users/dto/get-users-query.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetUsersQueryDto {
+	@IsOptional()
+	@Type(() => Number)
+	@IsInt()
+	@Min(0)
+	@Max(100)
+	limit?: number;
+
+	@IsOptional()
+	@Type(() => Number)
+	@IsInt()
+	@Min(0)
+	offset?: number;
+}

--- a/backend/src/users/dto/get-users-query.dto.ts
+++ b/backend/src/users/dto/get-users-query.dto.ts
@@ -1,19 +1,33 @@
 import { IsOptional, IsInt, Min, IsString, MaxLength } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class GetUsersQueryDto {
+	@ApiPropertyOptional({
+		example: 20,
+		description: 'Maximum number of users to return. Defaults to 20 and is capped to 100.',
+	})
 	@IsOptional()
 	@Type(() => Number)
 	@IsInt()
 	@Min(0)
 	limit?: number;
 
+	@ApiPropertyOptional({
+		example: 0,
+		description: 'Number of users to skip before returning results. Defaults to 0.',
+	})
 	@IsOptional()
 	@Type(() => Number)
 	@IsInt()
 	@Min(0)
 	offset?: number;
 
+	@ApiPropertyOptional({
+		example: 'nico',
+		description: 'Optional case-insensitive username search.',
+		maxLength: 50,
+	})
 	@IsOptional()
 	@IsString()
 	@MaxLength(50)

--- a/backend/src/users/dto/get-users-query.dto.ts
+++ b/backend/src/users/dto/get-users-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsInt, Min, IsString, MaxLength } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class GetUsersQueryDto {
@@ -13,4 +13,9 @@ export class GetUsersQueryDto {
 	@IsInt()
 	@Min(0)
 	offset?: number;
+
+	@IsOptional()
+	@IsString()
+	@MaxLength(50)
+	search?: string;
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -16,6 +16,7 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MatchesService } from 'src/modules/game/matches.service';
 import { AchievementsService } from 'src/modules/game/achievement/achievements.service';
+import { GetUsersQueryDto } from './dto/get-users-query.dto';
 
 @ApiTags('Users')
 @Controller('users')
@@ -42,11 +43,8 @@ export class UsersController {
 
 	@ApiOperation({ summary: 'Get all users' })
 	@Get()
-	getUsers(
-		@Query('limit') limit?: string,
-		@Query('offset') offset?: string,
-	) {
-		return this.usersService.getUsers(limit, offset);
+	getUsers(@Query() query: GetUsersQueryDto) {
+		return this.usersService.getUsers(query);
 	}
 
   @ApiOperation({ summary: 'Get user by ID' })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -45,6 +45,9 @@ export class UsersService {
 		const limit = Math.min(query.limit ?? 20, 100);
 		const offset = query.offset ?? 0;
 		const search = query.search?.trim();
+		if (query.search !== undefined && search === '') {
+			throw new BadRequestException('search cannot be empty or only spaces');
+		}
 		const where = search
 			? {
 					username: {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -44,10 +44,11 @@ export class UsersService {
 	async getUsers(query: { limit?: number; offset?: number; search?: string }) {
 		const limit = Math.min(query.limit ?? 20, 100);
 		const offset = query.offset ?? 0;
-		const where = query.search
+		const search = query.search?.trim();
+		const where = search
 			? {
 					username: {
-						contains: query.search,
+						contains: search,
 						mode: 'insensitive' as const,
 					},
 				}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -41,14 +41,14 @@ export class UsersService {
 	};
 }
 
-	async getUsers(limit?: string, offset?: string) {
-		const parsedLimit = Math.min(Number(limit) || 20, 100);
-		const parsedOffset = Number(offset) || 0;
+	async getUsers(query: { limit?: number; offset?: number }) {
+		const limit = Math.min(query.limit ?? 20, 100);
+		const offset = query.offset ?? 0;
 
 		const users = await this.prisma.user.findMany({
 			select: publicUserSelect,
-			take: parsedLimit,
-			skip: parsedOffset,
+			take: limit,
+			skip: offset,
 		});
 
 		return users.map(user => this.toPublicUser(user));

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -41,15 +41,24 @@ export class UsersService {
 	};
 }
 
-	async getUsers(query: { limit?: number; offset?: number }) {
+	async getUsers(query: { limit?: number; offset?: number; search?: string }) {
 		const limit = Math.min(query.limit ?? 20, 100);
 		const offset = query.offset ?? 0;
-
+		const where = query.search
+			? {
+					username: {
+						contains: query.search,
+						mode: 'insensitive' as const,
+					},
+				}
+			: {};
 		const users = await this.prisma.user.findMany({
+			where,
 			select: publicUserSelect,
 			take: limit,
 			skip: offset,
 		});
+
 
 		return users.map(user => this.toPublicUser(user));
 	}


### PR DESCRIPTION
## Summary

This PR improves `GET /users` by adding validated pagination query parameters and an optional username search.

It also ensures cleaner input handling by rejecting empty search strings and trimming user input.

Closes #245  
Closes #248

---

## What was done

- Added `GetUsersQueryDto`
- Validated query parameters using `class-validator`:
  - `limit` (optional, integer, >= 0)
  - `offset` (optional, integer, >= 0)
  - `search` (optional string, min length 1, max length 50)
- Converted query params using `@Type(() => Number)`
- Kept max limit enforcement (`100`) inside the service layer
- Added optional `search` query parameter
- Implemented case-insensitive username search using Prisma
- Trimmed search input in the service to avoid issues with leading/trailing spaces
- Added Swagger documentation for all query parameters

---

## Reasoning

- DTO validation ensures:
  - type safety
  - rejection of invalid inputs (negative numbers, non-numbers, empty strings)
- Service layer handles:
  - business rules (default values, max limit cap)
- Search is:
  - case-insensitive
  - partial match (`contains`)
  - sanitized (trimmed input)

---

## Tests

### Pagination

- `GET /api/users`
- `GET /api/users?limit=2`
- `GET /api/users?limit=2&offset=2`

### Search

- `GET /api/users?search=dummy`
- `GET /api/users?search=DUMMY`
- `GET /api/users?search=dummy&limit=2&offset=2`

### Validation

- `GET /api/users?limit=-5` → 400 ❌
- `GET /api/users?limit=abc` → 400 ❌
- `GET /api/users?search=` → 400 ❌ (min length 1)
- `GET /api/users?search=          ` → 400 ❌ (trim and then min length 1)
- `GET /api/users?search=     username` → handled correctly (trimmed input)
- `GET /api/users?search=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (50 chars) → valid ✅
- `GET /api/users?search=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` (51 chars) → 400 ❌

### Swagger

- Verified `limit`, `offset`, and `search` appear in Swagger UI
- Verified descriptions and examples are correctly displayed

---

## Notes

- Pagination cap (`100`) is enforced in the service, not the DTO, to separate validation from business logic
- Empty search queries are rejected to avoid ambiguous behavior
- Search input is trimmed to ensure consistent filtering

---

## Future work

- Add sorting in a separate PR if needed (e.g. `sortBy=username|xp|wins` and `order=asc|desc`)
- Add advanced filters later only if the frontend needs them
- Integrate search into frontend later for friends, chat, or invites

For sorting later , the clean API would be :
- GET /users?search=nico&sortBy=username&order=asc
- GET /users?sortBy=xp&order=desc