### PR TITLE
[FRONTEND] Achievements System — Display Achievments

### DIFF
--- a/backend/src/modules/game/achievement/achievements.lists.ts
+++ b/backend/src/modules/game/achievement/achievements.lists.ts
@@ -15,6 +15,6 @@ export const ACHIEVEMENTS: Record<AchievementKey, { key: AchievementKey, display
   LOSE_BY_TIME: { key: 'LOSE_BY_TIME', displayName: 'Noob', description: 'Lose a game by time.', iconName: "LOSE_BY_TIME_TROPHY" },
   WIN_5: { key: 'WIN_5', displayName: 'High Five', description: 'Win a total of 5 matches.', iconName: "WIN_5_TROPHY" },
   WIN_10: { key: 'WIN_10', displayName: 'Double Digits', description: 'Win a total of 10 matches.', iconName: "WIN_10_TROPHY" },
-  WIN_50: { key: 'WIN_50', displayName: 'Veteram', description: 'Win a total of 50 matches.', iconName: "WIN_50_TROPHY" },
+  WIN_50: { key: 'WIN_50', displayName: 'Veteran', description: 'Win a total of 50 matches.', iconName: "WIN_50_TROPHY" },
 
 } as const;

--- a/backend/src/modules/game/achievement/achievements.lists.ts
+++ b/backend/src/modules/game/achievement/achievements.lists.ts
@@ -7,14 +7,14 @@ export type AchievementKey =
     |   'WIN_10'
     |   'WIN_50'
 
-export const ACHIEVEMENTS: Record<AchievementKey, { key: AchievementKey, displayName: string, description: string }> = {
+export const ACHIEVEMENTS: Record<AchievementKey, { key: AchievementKey, displayName: string, description: string, iconName: string }> = {
 
-  FIRST_GAME: { key: 'FIRST_GAME', displayName: 'First of all', description: 'Play your first game.' },
-  FIRST_WIN: { key: 'FIRST_WIN', displayName: 'First Blood', description: 'Win your first game.' },
-  DRAW_GAME: { key: 'DRAW_GAME', displayName: 'Boring', description: 'Draw a game.' },
-  LOSE_BY_TIME: { key: 'LOSE_BY_TIME', displayName: 'Noob', description: 'Lose a game by time.' },
-  WIN_5: { key: 'WIN_5', displayName: 'High Five', description: 'Win a total of 5 matches.' },
-  WIN_10: { key: 'WIN_10', displayName: 'Double Digits', description: 'Win a total of 10 matches.' },
-  WIN_50: { key: 'WIN_50', displayName: 'Veteram', description: 'Win a total of 50 matches.' },
+  FIRST_GAME: { key: 'FIRST_GAME', displayName: 'First of all', description: 'Play your first game.', iconName: "FIRST_GAME_TROPHY" },
+  FIRST_WIN: { key: 'FIRST_WIN', displayName: 'First Blood', description: 'Win your first game.', iconName: "FIRST_WIN_TROPHY" },
+  DRAW_GAME: { key: 'DRAW_GAME', displayName: 'Boring', description: 'Draw a game.', iconName: "DRAW_GAME_TROPHY" },
+  LOSE_BY_TIME: { key: 'LOSE_BY_TIME', displayName: 'Noob', description: 'Lose a game by time.', iconName: "LOSE_BY_TIME_TROPHY" },
+  WIN_5: { key: 'WIN_5', displayName: 'High Five', description: 'Win a total of 5 matches.', iconName: "WIN_5_TROPHY" },
+  WIN_10: { key: 'WIN_10', displayName: 'Double Digits', description: 'Win a total of 10 matches.', iconName: "WIN_10_TROPHY" },
+  WIN_50: { key: 'WIN_50', displayName: 'Veteram', description: 'Win a total of 50 matches.', iconName: "WIN_50_TROPHY" },
 
 } as const;

--- a/backend/src/modules/game/achievement/achievements.service.ts
+++ b/backend/src/modules/game/achievement/achievements.service.ts
@@ -26,6 +26,10 @@ export class AchievementsService {
     });
   }
 
+  async getAllAchievements() {
+    return Object.values(ACHIEVEMENTS)
+  }
+
   async getAchievements(userId: number) {
     const userAchievement = await this.prismaService.userAchievement.findMany({
       where: { userId: userId },

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -39,11 +39,17 @@ export class UsersController {
 		private readonly achievementsService: AchievementsService,
 	) {}
 
-	@ApiOperation({ summary: 'Get all of achievements of users' })
-	@Get(':id/achievements')
-	getAchievements(@Param('id', ParseIntPipe) id: number) {
-		return this.achievementsService.getAchievements(id);
-	}
+  @ApiOperation({ summary: 'Get all existing achievements' })
+  @Get('allAchievements')
+  getAllAchievements() {
+    return this.achievementsService.getAllAchievements()
+  }
+
+  @ApiOperation({ summary: 'Get all of achievements of users' })
+  @Get(':id/achievements')
+  getAchievements(@Param('id', ParseIntPipe) id: number) {
+    return this.achievementsService.getAchievements(id);
+  }
 
 	@ApiOperation({ summary: 'Get leaderboard of users' })
 	@Get('leaderboard')

--- a/frontend/src/components/ui/AchievementIcons.tsx
+++ b/frontend/src/components/ui/AchievementIcons.tsx
@@ -1,0 +1,21 @@
+import {
+  Medal,
+  Trophy,
+  Bed,
+  ClockFading,
+  Skull,
+  Crosshair,
+  Infinity,
+} from "lucide-react";
+
+export const ACHIEVEMENT_ICONS = {
+  FIRST_GAME_TROPHY: Medal,
+  FIRST_WIN_TROPHY: Trophy,
+  DRAW_GAME_TROPHY: Bed,
+  LOSE_BY_TIME_TROPHY: ClockFading,
+  WIN_5_TROPHY: Crosshair,
+  WIN_10_TROPHY: Skull,
+  WIN_50_TROPHY: Infinity,
+} as const;
+
+export type IconKey = keyof typeof ACHIEVEMENT_ICONS

--- a/frontend/src/components/ui/AchievementIcons.tsx
+++ b/frontend/src/components/ui/AchievementIcons.tsx
@@ -1,4 +1,4 @@
-import { ACHIEVEMENT_ICONS, IconKey } from "@/type/achievements.types";
+import { ACHIEVEMENT_ICONS, type IconKey } from "@/type/achievements.types";
 import { Info, Lock } from "lucide-react";
 
 interface AchievementIconProps {

--- a/frontend/src/components/ui/AchievementIcons.tsx
+++ b/frontend/src/components/ui/AchievementIcons.tsx
@@ -1,21 +1,37 @@
-import {
-  Medal,
-  Trophy,
-  Bed,
-  ClockFading,
-  Skull,
-  Crosshair,
-  Infinity,
-} from "lucide-react";
+import { ACHIEVEMENT_ICONS, IconKey } from "@/type/achievements.types";
+import { Info, Lock } from "lucide-react";
 
-export const ACHIEVEMENT_ICONS = {
-  FIRST_GAME_TROPHY: Medal,
-  FIRST_WIN_TROPHY: Trophy,
-  DRAW_GAME_TROPHY: Bed,
-  LOSE_BY_TIME_TROPHY: ClockFading,
-  WIN_5_TROPHY: Crosshair,
-  WIN_10_TROPHY: Skull,
-  WIN_50_TROPHY: Infinity,
-} as const;
+interface AchievementIconProps {
+  iconName: string;
+  isUnlocked: boolean;
+  size?: number;
+  className?: string;
+}
 
-export type IconKey = keyof typeof ACHIEVEMENT_ICONS
+export function AchievementIcon({
+  iconName,
+  isUnlocked,
+  size = 24,
+  className = "",
+}: AchievementIconProps) {
+  const IconComponent = ACHIEVEMENT_ICONS[iconName as IconKey] || Info;
+
+  return (
+    <div className={`relative flex items-center justify-center ${className}`}>
+      <IconComponent
+        size={size}
+        className={`transition-all duration-500 ${
+          isUnlocked
+            ? "text-cyan-400 drop-shadow-[0_0_8px_rgba(34,211,238,0.5)]"
+            : "text-white/10 grayscale"
+        }`}
+      />
+
+      {!isUnlocked && (
+        <div className="absolute inset-0 flex items-center justify-center opacity-40">
+          <Lock size={size / 2} className="text-white/30" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -74,6 +74,7 @@
     "profile": {
         "loading": "Loading...",
         "level": "Level {{level}}",
+        "achievement": "Achievements",
         "stats": {
             "wins": "Wins",
             "losses": "Losses",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -74,6 +74,7 @@
     "profile": {
       "loading": "Cargando...",
       "level": "Nivel {{level}}",
+      "achievement": "Logros",
       "stats": {
         "wins": "Victorias",
         "losses": "Derrotas",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -74,6 +74,7 @@
     "profile": {
         "loading": "Chargement...",
         "level": "Niveau {{level}}",
+        "achievement": "Trophées",
         "stats": {
             "wins": "Victoires",
             "losses": "Défaites",

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -15,6 +15,7 @@ import { LevelProgress } from "@/components/ui/Level";
 import { Username } from "@/components/ui/Username";
 import { EmptyStateCard } from "@/components/ui/EmptyCard";
 import { useNavigate } from "react-router-dom";
+import { AchievementIcon } from "@/components/ui/AchievementIcons";
 
 interface User {
   id: number;
@@ -26,6 +27,13 @@ interface User {
   avatar: string;
   xp: number;
   isTwoFactorEnabled: boolean;
+}
+
+interface Achievement {
+  key: string;
+  displayName: string;
+  description: string;
+  iconName: string;
 }
 
 export default function Profile() {
@@ -40,6 +48,9 @@ export default function Profile() {
   const [userName, setUserName] = useState(user?.username || "");
   const [bio, setBio] = useState(user?.bio || "");
   const [loading, setLoading] = useState(true);
+
+  const [unlockedAchievements, setUnlockedAchievements] = useState<string[]>([])
+  const [allAchievements, setAllAchievements] = useState<Achievement[]>([]);
   //   const navigate = useNavigate()
 
   const [twoFactorCode, setTwoFactorCode] = useState("");
@@ -54,6 +65,28 @@ export default function Profile() {
     if (user) {
       setUserName(user.username);
       setBio(user.bio);
+
+      async function fetchAllAchievments() {
+        try {
+          const data = await userService.getAllAchievements()
+          setAllAchievements(data)
+        } catch (error) {
+          console.error("Failed to fetch all achievements: ", error)
+        }
+      }
+      fetchAllAchievments()
+
+      async function fetchAchievements() {
+        try {
+          const data = await userService.getAchievements(user!.id)
+          if (Array.isArray(data)) {
+            setUnlockedAchievements(data.map((a: any) => a.achievementId || a));
+          }
+        } catch (error) {
+          console.error("Failed to fetch achievements: ", error)
+        }
+      }
+      fetchAchievements()
 
       async function fetchhistory() {
         try {
@@ -232,9 +265,7 @@ export default function Profile() {
             />
           ) : (
             <h1 className="text-2xl font-bold tracking-wide">
-              <Username
-                name={user.username}
-                variant="profile"/>
+              <Username name={user.username} variant="profile" />
             </h1>
           )}
         </div>
@@ -262,6 +293,43 @@ export default function Profile() {
         {/* Level */}
         <LevelProgress xp={user.xp} />
 
+        {/* Achievements */}
+        <div className="mt-8">
+          <p className="text-white/50 text-sm mb-4">
+            {t("profile.achievement")}
+          </p>
+          <div className="grid grid-cols-4 gap-4">
+            {allAchievements.map((ach) => {
+              const isUnlocked = unlockedAchievements.includes(ach.key);
+
+              return (
+                <div
+                  key={ach.key}
+                  className="group relative flex flex-col items-center"
+                >
+                  <div
+                    className={`p-3 rounded-xl border transition-all ${
+                      isUnlocked
+                        ? "bg-cyan-500/10 border-cyan-500/30 shadow-[0_0_10px_rgba(6,182,212,0.2)]"
+                        : "bg-white/5 border-white/10 opacity-30 grayscale"
+                    }`}
+                  >
+                    <AchievementIcon
+                      iconName={ach.iconName}
+                      isUnlocked={isUnlocked}
+                      size={24}
+                    />
+                  </div>
+
+                  <div className="absolute -top-10 scale-0 group-hover:scale-100 transition-all bg-black/90 p-2 rounded text-[10px] z-50 pointer-events-none">
+                    <p className="font-bold text-cyan-400">{ach.displayName}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
         {/* BIO */}
         <div className="mt-8">
           <p className="text-white/50 text-sm mb-2">{t("profile.bio")}</p>
@@ -279,9 +347,7 @@ export default function Profile() {
         </div>
         {/* 2FA */}
         <div className="mt-8">
-          <p className="text-white/50 text-sm mb-2">
-            {t("auth.twofa.title")}
-          </p>
+          <p className="text-white/50 text-sm mb-2">{t("auth.twofa.title")}</p>
 
           {user.isTwoFactorEnabled ? (
             <div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
@@ -345,9 +411,7 @@ export default function Profile() {
 
         {/* BUTTON */}
         <Button onClick={handleSave} className="mt-8">
-          {isEdit 
-            ? t("profile.buttons.save")
-            : t("profile.buttons.edit")}
+          {isEdit ? t("profile.buttons.save") : t("profile.buttons.edit")}
         </Button>
       </div>
     </section>

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -84,7 +84,7 @@ export async function getAchievements(id: number) {
 }
 
 export async function getAllAchievements() {
-  const response = await api.get('allAchievements')
+  const response = await api.get('users/allAchievements')
   return response.data
 }
 

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -83,6 +83,11 @@ export async function getAchievements(id: number) {
   return response.data
 }
 
+export async function getAllAchievements() {
+  const response = await api.get('allAchievements')
+  return response.data
+}
+
 export const userService = {
     getUser,
     updateUser,
@@ -97,6 +102,7 @@ export const userService = {
     getLeaderboard,
     getAchievements,
 	uploadAvatar,
+  getAllAchievements,
 }
 
 export async function uploadAvatar(file: File) {

--- a/frontend/src/type/achievements.types.ts
+++ b/frontend/src/type/achievements.types.ts
@@ -1,0 +1,21 @@
+import {
+  Medal,
+  Trophy,
+  Bed,
+  ClockFading,
+  Skull,
+  Crosshair,
+  Infinity,
+} from "lucide-react";
+
+export const ACHIEVEMENT_ICONS = {
+  FIRST_GAME_TROPHY: Medal,
+  FIRST_WIN_TROPHY: Trophy,
+  DRAW_GAME_TROPHY: Bed,
+  LOSE_BY_TIME_TROPHY: ClockFading,
+  WIN_5_TROPHY: Crosshair,
+  WIN_10_TROPHY: Skull,
+  WIN_50_TROPHY: Infinity,
+} as const;
+
+export type IconKey = keyof typeof ACHIEVEMENT_ICONS


### PR DESCRIPTION
## Summary

Finalises the full End-to-End integration of the achievements system. 

---

## Files modified

| File | Description |
|------|-------------|
| `backend/.../achievements.service.ts` | Added `getAllAchievements` method to return the full catalogue |
| `backend/.../users.controller.ts` | Exposed `GET /users/allAchievements` endpoint |
| `frontend/.../userService.ts` | Added API calls for fetching catalogue and user achievements |
| `frontend/.../Profile.tsx` | Integrated achievements grid with state management and tooltips |
| `frontend/.../AchievementIcon.tsx` | Visual component handling grayscale, cyan highlight, and lock overlay |
| `frontend/.../achievements.types.ts` | Defined Lucide icon mapping and associated types |

---

## What was done

The main goal was to make the Frontend fully dynamic and independent from Backend source code while ensuring visual consistency.

### 1. Backend as Source of Truth

- **Catalogue endpoint:** The backend now exposes the `ACHIEVEMENTS` constant through a dedicated route, allowing the Frontend to automatically discover new achievements without code updates.
- **Standardised keys:** Unlocked achievements are returned using a unique `achievementId`, simplifying mapping and comparison on the client side.

### 2. Profile UI Implementation

- **State management:** Introduced two distinct states:
  - `allAchievements` (full catalogue)
  - `unlockedAchievements` (user-owned)
  
  These are compared to determine display state.

- **AchievementIcon component:**
  - **Unlocked:** Displayed in cyan-400 with a glow effect (`drop-shadow`)
  - **Locked:** Rendered in grayscale with reduced opacity and a lock overlay

- **Performance:** Data is fetched asynchronously inside the `useEffect` hook of the profile page.

---

## Why

- **Scalability:** Adding a new achievement in the backend is instantly reflected in the UI without frontend changes.

---

## How to test

### API — catalogue endpoint

Access the following route:

```
http://localhost:1024/api/users/allAchievements
```

Expected: Full list of achievements is returned.

---

### UI — profile page

1. Navigate to your profile page.

2. Verify that:
   - The achievements grid appears between the level bar and the biography.
   - Locked achievements are displayed in grayscale with a lock icon.
   - Unlocked achievements (e.g. `FIRST_GAME`) appear in cyan with a glow effect.
   - Hovering an icon displays its `displayName`.

3. Obtain the achievement and check your profile to see if it is unlocked.

