### PR TITLE
[SECURITY][USERS] Prevent avatar validation bypasses

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -76,7 +76,7 @@ export class AuthService {
 				passwordHash,
 				username: registerDto.username,
 				bio: registerDto.bio ?? '',
-				avatar: registerDto.avatar ?? '/default.png',
+				avatar: '/default.png',
 				wins: 0,
 				losses: 0,
 				draws: 0,

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -29,8 +29,8 @@ export class RegisterDto {
 		@MinLength(3)
 		@MaxLength(20)
 		@Matches(/^[a-zA-Z0-9_]+$/, {
-        	message: 'Username must not contain spaces'
-    	})
+			message: 'Username must not contain spaces'
+		})
 		username: string;
 
 		@ApiPropertyOptional({
@@ -41,6 +41,4 @@ export class RegisterDto {
 		@IsString()
 		@MaxLength(180)
 		bio?: string;
-
-
 }

--- a/backend/src/auth/dto/register.dto.ts
+++ b/backend/src/auth/dto/register.dto.ts
@@ -28,8 +28,8 @@ export class RegisterDto {
 		@IsString()
 		@MinLength(3)
 		@MaxLength(20)
-		@Matches(/^[a-zA-Z0-9_]+$/, { 
-        	message: 'Username must not contain spaces' 
+		@Matches(/^[a-zA-Z0-9_]+$/, {
+        	message: 'Username must not contain spaces'
     	})
 		username: string;
 
@@ -42,11 +42,5 @@ export class RegisterDto {
 		@MaxLength(180)
 		bio?: string;
 
-		@ApiPropertyOptional({
-				example: 'default.png',
-				description: 'Optional avatar filename or URL',
-		})
-		@IsOptional()
-		@IsString()
-		avatar?: string;
+
 }

--- a/backend/src/users/avatar-upload-rate-limit.guard.ts
+++ b/backend/src/users/avatar-upload-rate-limit.guard.ts
@@ -1,0 +1,41 @@
+import {
+	CanActivate,
+	ExecutionContext,
+	HttpException,
+	HttpStatus,
+	Injectable,
+} from '@nestjs/common';
+import type { AuthRequest } from '../auth/jwt-auth.guard';
+import {
+	AVATAR_UPLOAD_RATE_LIMIT_MAX_REQUESTS,
+	AVATAR_UPLOAD_RATE_LIMIT_WINDOW_MS,
+} from './avatar.constants';
+
+@Injectable()
+export class AvatarUploadRateLimitGuard implements CanActivate {
+	private readonly attemptsByUserId = new Map<number, number[]>();
+
+	canActivate(context: ExecutionContext): boolean {
+		const request = context.switchToHttp().getRequest<AuthRequest>();
+		const userId = request.user.sub;
+		const now = Date.now();
+
+		const previousAttempts = this.attemptsByUserId.get(userId) ?? [];
+
+		const recentAttempts = previousAttempts.filter(
+			(timestamp) => now - timestamp < AVATAR_UPLOAD_RATE_LIMIT_WINDOW_MS,
+		);
+
+		if (recentAttempts.length >= AVATAR_UPLOAD_RATE_LIMIT_MAX_REQUESTS) {
+			throw new HttpException(
+				'Too many avatar upload attempts. Please try again later.',
+				HttpStatus.TOO_MANY_REQUESTS,
+			);
+		}
+
+		recentAttempts.push(now);
+		this.attemptsByUserId.set(userId, recentAttempts);
+
+		return true;
+	}
+}

--- a/backend/src/users/avatar.constants.ts
+++ b/backend/src/users/avatar.constants.ts
@@ -5,3 +5,7 @@ export const AVATAR_ALLOWED_MIME_TYPES = [
 	'image/jpeg',
 	'image/webp',
 ] as const;
+
+export const AVATAR_UPLOAD_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+export const AVATAR_UPLOAD_RATE_LIMIT_MAX_REQUESTS = 10;

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -5,8 +5,8 @@ export class UpdateUserDto {
 	@IsString()
 	@MinLength(3, { message: 'Username is too short' })
 	@MaxLength(20, { message: 'Username is too long' })
-	@Matches(/^[a-zA-Z0-9_]+$/, { 
-        message: 'Username must not contain spaces' 
+	@Matches(/^[a-zA-Z0-9_]+$/, {
+        message: 'Username must not contain spaces'
     })
 	username?: string;
 
@@ -15,7 +15,4 @@ export class UpdateUserDto {
 	@MaxLength(180, { message: 'Bio is too long' })
 	bio?: string;
 
-	@IsOptional()
-	@IsString()
-	avatar?: string;
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -14,6 +14,7 @@ import {
 	UploadedFile,
 	UseInterceptors,
 	UseFilters,
+	UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -25,6 +26,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import type { AuthRequest } from '../auth/jwt-auth.guard';
 import { AVATAR_MAX_FILE_SIZE } from './avatar.constants';
 import { AvatarUploadExceptionFilter } from './avatar-upload.exception-filter';
+import { AvatarUploadRateLimitGuard } from './avatar-upload-rate-limit.guard';
 
 
 type SortBy = 'xp' | 'wins' | 'totalGames';
@@ -81,6 +83,7 @@ export class UsersController {
 		},
 	})
 	@Post('me/avatar')
+	@UseGuards(AvatarUploadRateLimitGuard)
 	@UseFilters(AvatarUploadExceptionFilter)
 	@UseInterceptors(
 		FileInterceptor('avatar', {

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -7,7 +7,7 @@ import { AvatarUploadRateLimitGuard } from './avatar-upload-rate-limit.guard';
 
 @Module({
 	imports: [PrismaModule, forwardRef(() => GameModule)],
-	providers: [UsersService, AvatarUploadRateLimitGuard, ],
+	providers: [UsersService, AvatarUploadRateLimitGuard],
 	controllers: [UsersController],
 	exports: [UsersService],
 })

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,11 +3,12 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { GameModule } from 'src/modules/game/game.module';
+import { AvatarUploadRateLimitGuard } from './avatar-upload-rate-limit.guard';
 
 @Module({
-  imports: [PrismaModule, forwardRef(() => GameModule)],
-  providers: [UsersService],
-  controllers: [UsersController],
-  exports: [UsersService],
+	imports: [PrismaModule, forwardRef(() => GameModule)],
+	providers: [UsersService, AvatarUploadRateLimitGuard, ],
+	controllers: [UsersController],
+	exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
## Summary

This PR closes the remaining avatar validation bypasses discovered after the validated avatar upload endpoint was added.

The dedicated endpoint:

```txt
POST /api/users/me/avatar
```

already validates uploaded files, but avatar data could still be changed through other routes that accepted raw avatar strings.

This PR makes the avatar upload endpoint the **only valid path** for changing avatar data.

It also adds a small per-user rate limit to the avatar upload endpoint to reduce abuse from repeated upload spam.

---

## Closes

Closes #265

---

## Problem

Before this PR, avatar validation could be bypassed through:

```txt
PATCH /api/users/:id
POST /api/auth/register
```

These routes could accept arbitrary avatar strings, including:

- SVG data URLs
- external tracking URLs
- very large strings
- non-image values

This meant that even though the upload endpoint was validated, another route could still write unsafe or invalid avatar data into the database.

---

## Security impact

This was not remote code execution, but it created several security and data-quality risks:

- inconsistent backend validation
- invalid avatar data stored in the database
- possible external tracking through avatar URLs
- larger API responses caused by oversized avatar strings
- bypass of the intended safe upload flow
- possible backend/database pressure from repeated avatar upload calls

---

## What changed

### 1. Removed avatar from profile update DTO

Updated:

```txt
backend/src/users/dto/update-user.dto.ts
```

Removed `avatar` from `UpdateUserDto`.

Result:

```txt
PATCH /api/users/:id
```

can no longer accept avatar values.

Because the global `ValidationPipe` uses:

```ts
whitelist: true
forbidNonWhitelisted: true
```

sending `avatar` now returns:

```txt
400 Bad Request
property avatar should not exist
```

---

### 2. Removed avatar from registration DTO

Updated:

```txt
backend/src/auth/dto/register.dto.ts
```

Removed `avatar` from `RegisterDto`.

Result:

```txt
POST /api/auth/register
```

can no longer accept arbitrary avatar values during account creation.

New users should receive the backend-controlled default avatar value from the service.

---

### 3. Kept only the validated upload endpoint for avatar changes

Avatar changes must now go through:

```txt
POST /api/users/me/avatar
```

This endpoint already performs avatar-specific validation:

- requires authenticated user
- uses `req.user.sub`
- has no `:id` route parameter
- validates upload size
- validates real file type from file bytes
- rejects SVG
- rejects fake images
- rejects oversized files
- stores a safe DB-backed data URL

---

### 4. Added per-user avatar upload rate limiting

Added:

```txt
backend/src/users/avatar-upload-rate-limit.guard.ts
```

The guard limits each authenticated user to:

```txt
10 avatar upload attempts per 60 seconds
```

New constants added in:

```txt
backend/src/users/avatar.constants.ts
```

```ts
AVATAR_UPLOAD_RATE_LIMIT_WINDOW_MS
AVATAR_UPLOAD_RATE_LIMIT_MAX_REQUESTS
```

If a user exceeds the limit, the endpoint returns:

```txt
429 Too Many Requests
Too many avatar upload attempts. Please try again later.
```

---

## Why the rate limit is placed before file parsing

The avatar upload route now runs in this order:

```txt
Global JwtAuthGuard
↓
AvatarUploadRateLimitGuard
↓
FileInterceptor / Multer
↓
Controller
↓
Service
↓
Prisma
```

This means repeated requests can be blocked before Multer parses the uploaded file.

That reduces backend pressure because rejected requests do not need to parse multipart data, inspect the file buffer, encode base64, or write to the database.

---

## Rate limiting limitation

This is an in-memory per-user rate limit.

It is good enough for the current local Docker/NestJS setup, but a distributed production deployment would need a shared rate-limit store such as Redis.

---

## Files changed

```txt
backend/src/auth/dto/register.dto.ts
backend/src/users/dto/update-user.dto.ts
backend/src/users/avatar.constants.ts
backend/src/users/avatar-upload-rate-limit.guard.ts
backend/src/users/users.controller.ts
backend/src/users/users.module.ts
```

---

# Testing

## 1. Setup

Run the project:

```bash
make up
```

Set variables:

```bash
export ROOT="http://127.0.0.1:1024"
export BASE="$ROOT/api"
export EMAIL="dummy5@mail.com"
export PASS="Dummy123"
export COOKIE="/tmp/cookie.jar"
```

Login and save the cookie:

```bash
curl -i -c "$COOKIE" \
	-H "Content-Type: application/json" \
	-d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
	"$BASE/auth/login"
```

For the tests below, user id `6` was used locally.

If needed, get the authenticated user manually:

```bash
curl -s -b "$COOKIE" "$BASE/auth/me"
```

---

## 2. PATCH avatar external URL bypass

Test:

```bash
curl -i -b "$COOKIE" \
	-X PATCH "$BASE/users/6" \
	-H "Content-Type: application/json" \
	-d '{"avatar":"http://127.0.0.1:9999/tracker.png?from=avatar"}'
```

Expected:

```txt
400 Bad Request
property avatar should not exist
```

Observed:

```txt
HTTP/1.1 400 Bad Request
{"message":["property avatar should not exist"],"error":"Bad Request","statusCode":400}
```

---

## 3. PATCH large avatar string bypass

Create large payload:

```bash
python3 - << 'PY' > /tmp/long-avatar.json
import json
print(json.dumps({"avatar": "A" * 50000}))
PY
```

Test:

```bash
curl -i -b "$COOKIE" \
	-X PATCH "$BASE/users/6" \
	-H "Content-Type: application/json" \
	--data-binary @/tmp/long-avatar.json
```

Expected:

```txt
400 Bad Request
property avatar should not exist
```

Observed:

```txt
HTTP/1.1 400 Bad Request
{"message":["property avatar should not exist"],"error":"Bad Request","statusCode":400}
```

---

## 4. Register with arbitrary avatar bypass

Set values:

```bash
export TS=$(date +%s)
export NEW_EMAIL="attacker$TS@mail.com"
export NEW_USERNAME="attacker$TS"
```

Test:

```bash
curl -i -X POST "$BASE/auth/register" \
	-H "Content-Type: application/json" \
	-d "{
		\"email\": \"$NEW_EMAIL\",
		\"password\": \"Attack123\",
		\"username\": \"$NEW_USERNAME\",
		\"avatar\": \"http://127.0.0.1:9999/tracker.png?from=register\"
	}"
```

Expected:

```txt
400 Bad Request
property avatar should not exist
```

Observed:

```txt
HTTP/1.1 400 Bad Request
{"message":["property avatar should not exist"],"error":"Bad Request","statusCode":400}
```

---

## 5. Valid avatar upload still works

Create tiny valid PNG:

```bash
export AVATAR="/tmp/bug.png"

printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' \
	| base64 -d > "$AVATAR"
```

Test:

```bash
curl -i -b "$COOKIE" \
	-F "avatar=@$AVATAR;type=image/png" \
	"$BASE/users/me/avatar"
```

Expected:

```txt
201 Created
avatar starts with data:image/png;base64,
```

Observed:

```txt
HTTP/1.1 201 Created
"avatar":"data:image/png;base64,..."
```

---

## 6. Avatar upload rate limit

Create tiny valid PNG if not already created:

```bash
export AVATAR="/tmp/bug.png"

printf 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=' \
	| base64 -d > "$AVATAR"
```

Run controlled parallel test:

```bash
seq 1 15 | xargs -P5 -I{} sh -c '
	curl -s -o /dev/null -w "{} => %{http_code}\n" \
		-b "'"$COOKIE"'" \
		-F "avatar=@'"$AVATAR"';type=image/png" \
		"'"$BASE"'/users/me/avatar"
'
```

Expected:

```txt
First 10 requests → 201
Requests after limit → 429
```

Observed:

```txt
2 => 201
3 => 201
1 => 201
5 => 201
4 => 201
6 => 201
8 => 201
7 => 201
9 => 201
10 => 201
11 => 429
12 => 429
13 => 429
14 => 429
15 => 429
```

---

## 7. Valid upload works again after rate-limit window

Wait at least 60 seconds, then run:

```bash
curl -i -b "$COOKIE" \
	-F "avatar=@/tmp/bug.png;type=image/png" \
	"$BASE/users/me/avatar"
```

Expected:

```txt
201 Created
```

Observed:

```txt
HTTP/1.1 201 Created
```

---

## Final result

The avatar field can no longer be changed through raw DTO input.

Allowed avatar update path:

```txt
POST /api/users/me/avatar
```

Blocked avatar bypass paths:

```txt
PATCH /api/users/:id
POST /api/auth/register
```

Additional protection:

```txt
Per-user avatar upload rate limit: 10 attempts per 60 seconds
```


