### PR TITLE
[BACKEND][FRIENDS] Add friend requests and friends list

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -12,26 +12,30 @@ datasource db {
 }
 
 model User {
-  id                  Int            @id @default(autoincrement())
-  email               String         @unique
-  passwordHash        String?
-  username            String         @unique
-  bio                 String?
-  avatar              String
-  wins                Int            @default(0)
-  losses              Int            @default(0)
-  draws               Int            @default(0)
-  xp                  Int            @default(0)
-  totalGames          Int            @default(0)
-  isTwoFactorEnabled  Boolean        @default(false)
-  twoFactorSecret     String?
-  twoFactorTempSecret String?
-  gameAsP1            Game[]         @relation("player1")
-  gameAsP2            Game[]         @relation("player2")
-  wonGamees           Game[]         @relation("asWinner")
-  moves               Move[]
-  oauthAccounts       OAuthAccount[]
-  achievements        UserAchievement[]
+  id                     Int               @id @default(autoincrement())
+  email                  String            @unique
+  passwordHash           String?
+  username               String            @unique
+  bio                    String?
+  avatar                 String
+  wins                   Int               @default(0)
+  losses                 Int               @default(0)
+  draws                  Int               @default(0)
+  xp                     Int               @default(0)
+  totalGames             Int               @default(0)
+  isTwoFactorEnabled     Boolean           @default(false)
+  twoFactorSecret        String?
+  twoFactorTempSecret    String?
+  gameAsP1               Game[]            @relation("player1")
+  gameAsP2               Game[]            @relation("player2")
+  wonGamees              Game[]            @relation("asWinner")
+  moves                  Move[]
+  oauthAccounts          OAuthAccount[]
+  achievements           UserAchievement[]
+  sentFriendRequests     Friend[]          @relation("FriendSender")
+  receivedFriendRequests Friend[]          @relation("FriendReceiver")
+  friendPairsAsA         Friend[]          @relation("FriendUserA")
+  friendPairsAsB         Friend[]          @relation("FriendUserB")
 }
 
 model OAuthAccount {
@@ -41,46 +45,74 @@ model OAuthAccount {
   userId         Int
   createdAt      DateTime @default(now())
 
-  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerUserId])
 }
 
 model Game {
-  id           Int      @id @default(autoincrement())
-  player1      User     @relation("player1", fields: [player1Id], references: [id])
-  player1Id    Int
-  player2      User     @relation("player2", fields: [player2Id], references: [id])
-  player2Id    Int
-  winner       User?    @relation("asWinner", fields: [winnerId], references: [id])
-  winnerId     Int?
-  scoresP1     Int      @default(0)
-  scoresP2     Int      @default(0)
-  date         DateTime @default(now())
-  endReason    String?
-  moves        Move[]
-
+  id        Int      @id @default(autoincrement())
+  player1   User     @relation("player1", fields: [player1Id], references: [id])
+  player1Id Int
+  player2   User     @relation("player2", fields: [player2Id], references: [id])
+  player2Id Int
+  winner    User?    @relation("asWinner", fields: [winnerId], references: [id])
+  winnerId  Int?
+  scoresP1  Int      @default(0)
+  scoresP2  Int      @default(0)
+  date      DateTime @default(now())
+  endReason String?
+  moves     Move[]
 }
 
 model Move {
-  id           Int     @id @default(autoincrement())
-  position     Int
-  moveOrder    Int
-  game         Game    @relation(fields: [gameId], references: [id])
-  gameId       Int
-  player       User    @relation(fields: [playerId], references: [id])
-  playerId     Int
-
+  id        Int  @id @default(autoincrement())
+  position  Int
+  moveOrder Int
+  game      Game @relation(fields: [gameId], references: [id])
+  gameId    Int
+  player    User @relation(fields: [playerId], references: [id])
+  playerId  Int
 }
 
 model UserAchievement {
-  userId          Int
-  key             String
-  unlockedAt      DateTime  @default(now())
-  progress        Int?
+  userId     Int
+  key        String
+  unlockedAt DateTime @default(now())
+  progress   Int?
 
-  user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([userId, key])
-  
+}
+
+enum FriendStatus {
+  PENDING
+  ACCEPTED
+}
+
+model Friend {
+  id Int @id @default(autoincrement())
+
+  senderId   Int
+  receiverId Int
+
+  userAId Int
+  userBId Int
+
+  status FriendStatus @default(PENDING)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  sender   User @relation("FriendSender", fields: [senderId], references: [id], onDelete: Cascade)
+  receiver User @relation("FriendReceiver", fields: [receiverId], references: [id], onDelete: Cascade)
+
+  userA User @relation("FriendUserA", fields: [userAId], references: [id], onDelete: Cascade)
+  userB User @relation("FriendUserB", fields: [userBId], references: [id], onDelete: Cascade)
+
+  @@unique([userAId, userBId])
+  @@index([senderId])
+  @@index([receiverId])
+  @@index([status])
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,9 +8,10 @@ import { AuthModule } from './auth/auth.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { ChatModule } from './modules/chat/chat.modules';
+import { FriendsModule } from './friends/friends.module';
 
 @Module({
-  imports: [UsersModule, PrismaModule, AuthModule, GameModule, ChatModule],
+  imports: [UsersModule, PrismaModule, AuthModule, GameModule, ChatModule, FriendsModule],
   controllers: [AppController],
   providers: [
     AppService,

--- a/backend/src/friends/dto/respond-friend-request.dto.ts
+++ b/backend/src/friends/dto/respond-friend-request.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+
+export enum FriendRequestAction {
+	ACCEPT = 'ACCEPT',
+	DECLINE = 'DECLINE',
+}
+
+export class RespondFriendRequestDto {
+	@ApiProperty({
+		enum: FriendRequestAction,
+		example: FriendRequestAction.ACCEPT,
+	})
+	@IsEnum(FriendRequestAction)
+	action: FriendRequestAction;
+}

--- a/backend/src/friends/friends.constants.ts
+++ b/backend/src/friends/friends.constants.ts
@@ -1,0 +1,2 @@
+export const MAX_PENDING_FRIEND_REQUESTS = 50;
+export const MAX_FRIEND_RESULTS = 100;

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -9,7 +9,7 @@ import {
 	Body,
 	Delete,
 } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiTags, ApiResponse } from '@nestjs/swagger';
 import type { AuthRequest } from '../auth/jwt-auth.guard';
 import { FriendsService } from './friends.service';
 import { RespondFriendRequestDto } from './dto/respond-friend-request.dto';

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -5,10 +5,13 @@ import {
 	Param,
 	ParseIntPipe,
 	Req,
+	Patch,
+	Body,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import type { AuthRequest } from '../auth/jwt-auth.guard';
 import { FriendsService } from './friends.service';
+import { RespondFriendRequestDto } from './dto/respond-friend-request.dto';
 
 @ApiTags('Friends')
 @Controller('friends')
@@ -42,5 +45,24 @@ export class FriendsController {
 	@Get('requests/outgoing')
 	getOutgoingRequests(@Req() req: AuthRequest) {
 		return this.friendsService.getOutgoingRequests(req.user.sub);
+	}
+
+	@ApiOperation({ summary: 'Accept or decline incoming friend request' })
+	@ApiParam({
+		name: 'requestId',
+		description: 'Friend request ID',
+		example: 1,
+	})
+	@Patch('requests/:requestId')
+	respondToFriendRequest(
+		@Param('requestId', ParseIntPipe) requestId: number,
+		@Body() body: RespondFriendRequestDto,
+		@Req() req: AuthRequest,
+	) {
+		return this.friendsService.respondToFriendRequest(
+			req.user.sub,
+			requestId,
+			body.action,
+		);
 	}
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { FriendsService } from './friends.service';
+
+@ApiTags('Friends')
+@Controller('friends')
+export class FriendsController {
+	constructor(private readonly friendsService: FriendsService) {}
+}

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -1,6 +1,7 @@
 import {
 	Controller,
 	Post,
+	Get,
 	Param,
 	ParseIntPipe,
 	Req,
@@ -29,5 +30,11 @@ export class FriendsController {
 			req.user.sub,
 			userId,
 		);
+	}
+
+	@ApiOperation({ summary: 'List incoming friend requests' })
+	@Get('requests/incoming')
+	getIncomingRequests(@Req() req: AuthRequest) {
+		return this.friendsService.getIncomingRequests(req.user.sub);
 	}
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -1,9 +1,33 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+	Controller,
+	Post,
+	Param,
+	ParseIntPipe,
+	Req,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import type { AuthRequest } from '../auth/jwt-auth.guard';
 import { FriendsService } from './friends.service';
 
 @ApiTags('Friends')
 @Controller('friends')
 export class FriendsController {
 	constructor(private readonly friendsService: FriendsService) {}
+
+	@ApiOperation({ summary: 'Send friend request' })
+	@ApiParam({
+		name: 'userId',
+		description: 'Target user ID',
+		example: 2,
+	})
+	@Post('requests/:userId')
+	sendFriendRequest(
+		@Param('userId', ParseIntPipe) userId: number,
+		@Req() req: AuthRequest,
+	) {
+		return this.friendsService.sendFriendRequest(
+			req.user.sub,
+			userId,
+		);
+	}
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -25,6 +25,14 @@ export class FriendsController {
 		description: 'Target user ID',
 		example: 2,
 	})
+	@ApiResponse({
+		status: 201,
+		description: 'Friend request sent successfully',
+	})
+	@ApiResponse({
+		status: 409,
+		description: 'Friend request already exists',
+	})
 	@Post('requests/:userId')
 	sendFriendRequest(
 		@Param('userId', ParseIntPipe) userId: number,

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -37,4 +37,10 @@ export class FriendsController {
 	getIncomingRequests(@Req() req: AuthRequest) {
 		return this.friendsService.getIncomingRequests(req.user.sub);
 	}
+
+	@ApiOperation({ summary: 'List outgoing friend requests' })
+	@Get('requests/outgoing')
+	getOutgoingRequests(@Req() req: AuthRequest) {
+		return this.friendsService.getOutgoingRequests(req.user.sub);
+	}
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -65,4 +65,10 @@ export class FriendsController {
 			body.action,
 		);
 	}
+
+	@ApiOperation({ summary: 'List accepted friends' })
+	@Get()
+	getFriends(@Req() req: AuthRequest) {
+		return this.friendsService.getFriends(req.user.sub);
+	}
 }

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -7,6 +7,7 @@ import {
 	Req,
 	Patch,
 	Body,
+	Delete,
 } from '@nestjs/common';
 import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 import type { AuthRequest } from '../auth/jwt-auth.guard';
@@ -70,5 +71,22 @@ export class FriendsController {
 	@Get()
 	getFriends(@Req() req: AuthRequest) {
 		return this.friendsService.getFriends(req.user.sub);
+	}
+
+	@ApiOperation({ summary: 'Remove accepted friend' })
+	@ApiParam({
+		name: 'friendshipId',
+		description: 'Accepted friendship ID',
+		example: 1,
+	})
+	@Delete(':friendshipId')
+	removeFriend(
+		@Param('friendshipId', ParseIntPipe) friendshipId: number,
+		@Req() req: AuthRequest,
+	) {
+		return this.friendsService.removeFriend(
+			req.user.sub,
+			friendshipId,
+		);
 	}
 }

--- a/backend/src/friends/friends.module.ts
+++ b/backend/src/friends/friends.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { FriendsController } from './friends.controller';
+import { FriendsService } from './friends.service';
+
+@Module({
+	imports: [PrismaModule],
+	controllers: [FriendsController],
+	providers: [FriendsService],
+})
+export class FriendsModule {}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -5,7 +5,7 @@ import {
 	NotFoundException,
 	ForbiddenException,
 } from '@nestjs/common';
-import { FriendStatus } from '@prisma/client';
+import { FriendStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { FriendRequestAction } from './dto/respond-friend-request.dto';
 
@@ -55,26 +55,39 @@ export class FriendsService {
 			);
 		}
 
-		const request = await this.prisma.friend.create({
-			data: {
-				senderId,
-				receiverId,
-				userAId,
-				userBId,
-				status: FriendStatus.PENDING,
-			},
-			select: {
-				id: true,
-				status: true,
-				createdAt: true,
-			},
-		});
+		try {
+			const request = await this.prisma.friend.create({
+				data: {
+					senderId,
+					receiverId,
+					userAId,
+					userBId,
+					status: FriendStatus.PENDING,
+				},
+				select: {
+					id: true,
+					status: true,
+					createdAt: true,
+				},
+			});
 
-		return {
-			requestId: request.id,
-			status: request.status,
-			createdAt: request.createdAt,
-		};
+			return {
+				requestId: request.id,
+				status: request.status,
+				createdAt: request.createdAt,
+			};
+		} catch (error) {
+			if (
+				error instanceof Prisma.PrismaClientKnownRequestError &&
+				error.code === 'P2002'
+			) {
+				throw new ConflictException(
+					'Friend request or friendship already exists',
+				);
+			}
+
+			throw error;
+		}
 	}
 
 	async getIncomingRequests(userId: number) {
@@ -83,6 +96,7 @@ export class FriendsService {
 				receiverId: userId,
 				status: FriendStatus.PENDING,
 			},
+			take: 100,
 			select: {
 				id: true,
 				createdAt: true,
@@ -117,6 +131,7 @@ export class FriendsService {
 				senderId: userId,
 				status: FriendStatus.PENDING,
 			},
+			take: 100,
 			select: {
 				id: true,
 				createdAt: true,
@@ -211,6 +226,7 @@ export class FriendsService {
 					{ receiverId: userId },
 				],
 			},
+			take: 100,
 			select: {
 				id: true,
 				createdAt: true,

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class FriendsService {
+	constructor(private readonly prisma: PrismaService) {}
+}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -55,7 +55,7 @@ export class FriendsService {
 			);
 		}
 
-		return this.prisma.friend.create({
+		const request = await this.prisma.friend.create({
 			data: {
 				senderId,
 				receiverId,
@@ -63,7 +63,18 @@ export class FriendsService {
 				userBId,
 				status: FriendStatus.PENDING,
 			},
+			select: {
+				id: true,
+				status: true,
+				createdAt: true,
+			},
 		});
+
+		return {
+			requestId: request.id,
+			status: request.status,
+			createdAt: request.createdAt,
+		};
 	}
 
 	async getIncomingRequests(userId: number) {
@@ -177,9 +188,18 @@ export class FriendsService {
 			data: {
 				status: FriendStatus.ACCEPTED,
 			},
+			select: {
+				id: true,
+				status: true,
+				updatedAt: true,
+			},
 		});
 
-		return updatedRequest;
+		return {
+			friendshipId: updatedRequest.id,
+			status: updatedRequest.status,
+			updatedAt: updatedRequest.updatedAt,
+		};
 	}
 
 	async getFriends(userId: number) {

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -181,4 +181,58 @@ export class FriendsService {
 
 		return updatedRequest;
 	}
+
+	async getFriends(userId: number) {
+		const friendships = await this.prisma.friend.findMany({
+			where: {
+				status: FriendStatus.ACCEPTED,
+				OR: [
+					{ senderId: userId },
+					{ receiverId: userId },
+				],
+			},
+			select: {
+				id: true,
+				createdAt: true,
+				senderId: true,
+				receiverId: true,
+				sender: {
+					select: {
+						id: true,
+						username: true,
+						bio: true,
+						avatar: true,
+						wins: true,
+						losses: true,
+						draws: true,
+						xp: true,
+					},
+				},
+				receiver: {
+					select: {
+						id: true,
+						username: true,
+						bio: true,
+						avatar: true,
+						wins: true,
+						losses: true,
+						draws: true,
+						xp: true,
+					},
+				},
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+		});
+
+		return friendships.map((friendship) => ({
+			friendshipId: friendship.id,
+			friend:
+				friendship.senderId === userId
+					? friendship.receiver
+					: friendship.sender,
+			createdAt: friendship.createdAt,
+		}));
+	}
 }

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -235,4 +235,41 @@ export class FriendsService {
 			createdAt: friendship.createdAt,
 		}));
 	}
+
+	async removeFriend(userId: number, friendshipId: number) {
+		const friendship = await this.prisma.friend.findUnique({
+			where: { id: friendshipId },
+			select: {
+				id: true,
+				senderId: true,
+				receiverId: true,
+				status: true,
+			},
+		});
+
+		if (!friendship) {
+			throw new NotFoundException('Friendship not found');
+		}
+
+		if (friendship.status !== FriendStatus.ACCEPTED) {
+			throw new BadRequestException('Only accepted friendships can be removed');
+		}
+
+		if (
+			friendship.senderId !== userId &&
+			friendship.receiverId !== userId
+		) {
+			throw new ForbiddenException(
+				'You can only remove your own friendships',
+			);
+		}
+
+		await this.prisma.friend.delete({
+			where: { id: friendshipId },
+		});
+
+		return {
+			message: 'Friend removed',
+		};
+	}
 }

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -1,7 +1,0 @@
-import { Injectable } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
-
-@Injectable()
-export class FriendsService {
-	constructor(private readonly prisma: PrismaService) {}
-}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -3,9 +3,11 @@ import {
 	ConflictException,
 	Injectable,
 	NotFoundException,
+	ForbiddenException,
 } from '@nestjs/common';
 import { FriendStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { FriendRequestAction } from './dto/respond-friend-request.dto';
 
 @Injectable()
 export class FriendsService {
@@ -130,5 +132,53 @@ export class FriendsService {
 			receiver: request.receiver,
 			createdAt: request.createdAt,
 		}));
+	}
+
+	async respondToFriendRequest(
+		userId: number,
+		requestId: number,
+		action: FriendRequestAction,
+	) {
+		const request = await this.prisma.friend.findUnique({
+			where: { id: requestId },
+			select: {
+				id: true,
+				receiverId: true,
+				status: true,
+			},
+		});
+
+		if (!request) {
+			throw new NotFoundException('Friend request not found');
+		}
+
+		if (request.receiverId !== userId) {
+			throw new ForbiddenException(
+				'You can only respond to friend requests sent to you',
+			);
+		}
+
+		if (request.status !== FriendStatus.PENDING) {
+			throw new ConflictException('Friend request is not pending');
+		}
+
+		if (action === FriendRequestAction.DECLINE) {
+			await this.prisma.friend.delete({
+				where: { id: requestId },
+			});
+
+			return {
+				message: 'Friend request declined',
+			};
+		}
+
+		const updatedRequest = await this.prisma.friend.update({
+			where: { id: requestId },
+			data: {
+				status: FriendStatus.ACCEPTED,
+			},
+		});
+
+		return updatedRequest;
 	}
 }

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -63,4 +63,38 @@ export class FriendsService {
 			},
 		});
 	}
+	
+	async getIncomingRequests(userId: number) {
+		const requests = await this.prisma.friend.findMany({
+			where: {
+				receiverId: userId,
+				status: FriendStatus.PENDING,
+			},
+			select: {
+				id: true,
+				createdAt: true,
+				sender: {
+					select: {
+						id: true,
+						username: true,
+						bio: true,
+						avatar: true,
+						wins: true,
+						losses: true,
+						draws: true,
+						xp: true,
+					},
+				},
+			},
+			orderBy: {
+				createdAt: 'desc',
+			},
+		});
+
+		return requests.map((request) => ({
+			requestId: request.id,
+			sender: request.sender,
+			createdAt: request.createdAt,
+		}));
+	}
 }

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -63,7 +63,7 @@ export class FriendsService {
 			},
 		});
 	}
-	
+
 	async getIncomingRequests(userId: number) {
 		const requests = await this.prisma.friend.findMany({
 			where: {
@@ -94,6 +94,40 @@ export class FriendsService {
 		return requests.map((request) => ({
 			requestId: request.id,
 			sender: request.sender,
+			createdAt: request.createdAt,
+		}));
+	}
+
+	async getOutgoingRequests(userId: number) {
+		const requests = await this.prisma.friend.findMany({
+			where: {
+				senderId: userId,
+				status: FriendStatus.PENDING,
+			},
+			select: {
+				id: true,
+				createdAt: true,
+				receiver: {
+					select: {
+						id: true,
+						username: true,
+						bio: true,
+						avatar: true,
+						wins: true,
+						losses: true,
+						draws: true,
+						xp: true,
+					},
+				},
+			},
+			orderBy: {
+				createdAt: 'desc',
+			},
+		});
+
+		return requests.map((request) => ({
+			requestId: request.id,
+			receiver: request.receiver,
 			createdAt: request.createdAt,
 		}));
 	}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -1,0 +1,66 @@
+import {
+	BadRequestException,
+	ConflictException,
+	Injectable,
+	NotFoundException,
+} from '@nestjs/common';
+import { FriendStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class FriendsService {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async sendFriendRequest(senderId: number, receiverId: number) {
+		if (senderId === receiverId) {
+			throw new BadRequestException(
+				'You cannot send a friend request to yourself',
+			);
+		}
+
+		const receiver = await this.prisma.user.findUnique({
+			where: { id: receiverId },
+			select: { id: true },
+		});
+
+		if (!receiver) {
+			throw new NotFoundException('User not found');
+		}
+
+		const userAId = Math.min(senderId, receiverId);
+		const userBId = Math.max(senderId, receiverId);
+
+		const existingFriendship = await this.prisma.friend.findUnique({
+			where: {
+				userAId_userBId: {
+					userAId,
+					userBId,
+				},
+			},
+			select: {
+				id: true,
+				status: true,
+			},
+		});
+
+		if (existingFriendship) {
+			if (existingFriendship.status === FriendStatus.ACCEPTED) {
+				throw new ConflictException('Users are already friends');
+			}
+
+			throw new ConflictException(
+				'Friend request already exists',
+			);
+		}
+
+		return this.prisma.friend.create({
+			data: {
+				senderId,
+				receiverId,
+				userAId,
+				userBId,
+				status: FriendStatus.PENDING,
+			},
+		});
+	}
+}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -8,6 +8,7 @@ import {
 import { FriendStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { FriendRequestAction } from './dto/respond-friend-request.dto';
+import { MAX_PENDING_FRIEND_REQUESTS, MAX_FRIEND_RESULTS} from './friends.constants';
 
 @Injectable()
 export class FriendsService {
@@ -55,6 +56,19 @@ export class FriendsService {
 			);
 		}
 
+		const pendingOutgoingCount = await this.prisma.friend.count({
+			where: {
+				senderId,
+				status: FriendStatus.PENDING,
+			},
+		});
+
+		if (pendingOutgoingCount >= MAX_PENDING_FRIEND_REQUESTS) {
+			throw new BadRequestException(
+				'You have too many pending friend requests',
+			);
+		}
+
 		try {
 			const request = await this.prisma.friend.create({
 				data: {
@@ -96,7 +110,7 @@ export class FriendsService {
 				receiverId: userId,
 				status: FriendStatus.PENDING,
 			},
-			take: 100,
+			take: MAX_FRIEND_RESULTS,
 			select: {
 				id: true,
 				createdAt: true,
@@ -131,7 +145,7 @@ export class FriendsService {
 				senderId: userId,
 				status: FriendStatus.PENDING,
 			},
-			take: 100,
+			take: MAX_FRIEND_RESULTS,
 			select: {
 				id: true,
 				createdAt: true,
@@ -226,7 +240,7 @@ export class FriendsService {
 					{ receiverId: userId },
 				],
 			},
-			take: 100,
+			take: MAX_FRIEND_RESULTS,
 			select: {
 				id: true,
 				createdAt: true,


### PR DESCRIPTION
## Summary

This PR adds the backend foundation for the friends system.

Authenticated users can now:

- send friend requests
- view incoming pending requests
- view outgoing pending requests
- accept or decline received requests
- list accepted friends
- remove/unfriend accepted friends

The implementation follows the existing backend architecture:

```txt
Guard → Controller → Service → Prisma → DB
```

The sender of a friend request is always taken from the authenticated JWT user, not from the request body.

---

## Files changed

| File | Purpose |
|---|---|
| `backend/prisma/schema.prisma` | Adds `FriendStatus` enum and `Friend` model |
| `backend/src/app.module.ts` | Registers `FriendsModule` |
| `backend/src/friends/friends.module.ts` | Adds the Friends feature module |
| `backend/src/friends/friends.controller.ts` | Adds Friends HTTP endpoints |
| `backend/src/friends/friends.service.ts` | Adds friend request and friendship business logic |
| `backend/src/friends/dto/respond-friend-request.dto.ts` | Adds validated accept/decline action DTO |
| `backend/src/friends/friends.constants.ts` | Centralizes friends-related security limits |

---

## What was implemented

### 1. Friend model

Added a new `Friend` model with:

```txt
id
senderId
receiverId
userAId
userBId
status
createdAt
updatedAt
```

Added status enum:

```prisma
enum FriendStatus {
  PENDING
  ACCEPTED
}
```

The system does not store `DECLINED` in the first version.

Declining a request deletes the pending row.

Unfriending also deletes the accepted row.

---

### 2. Directional request + symmetric friendship design

Friend requests are directional:

```txt
senderId → receiverId
```

Example:

```txt
Alice sends request to Bob
senderId = Alice
receiverId = Bob
status = PENDING
```

Accepted friendships are symmetric:

```txt
Alice is Bob's friend
Bob is Alice's friend
```

The original `senderId` and `receiverId` remain stored because the friendship started as a request.

---

### 3. Reverse duplicate protection

The model also stores a normalized pair:

```txt
userAId = smaller user id
userBId = bigger user id
```

Example:

```txt
Alice id = 11
Bob id = 12

Alice → Bob gives:
userAId = 11
userBId = 12

Bob → Alice also gives:
userAId = 11
userBId = 12
```

This allows the database to enforce one relationship per pair:

```prisma
@@unique([userAId, userBId])
```

This prevents both of these rows from existing:

```txt
11 → 12
12 → 11
```

---

## Endpoints added

### Send friend request

```txt
POST /friends/requests/:userId
```

Rules:

- user must be authenticated
- sender comes from `req.user.sub`
- target user comes from `:userId`
- user cannot friend themselves
- target user must exist
- duplicate and reverse-duplicate requests are blocked
- already accepted friendships are blocked
- response uses a clean API shape

Example response:

```json
{
  "requestId": 3,
  "status": "PENDING",
  "createdAt": "2026-05-09T08:38:08.789Z"
}
```

---

### List incoming requests

```txt
GET /friends/requests/incoming
```

Returns pending requests where the authenticated user is the receiver.

Example response:

```json
[
  {
    "requestId": 3,
    "sender": {
      "id": 11,
      "username": "alice",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

---

### List outgoing requests

```txt
GET /friends/requests/outgoing
```

Returns pending requests where the authenticated user is the sender.

Example response:

```json
[
  {
    "requestId": 3,
    "receiver": {
      "id": 12,
      "username": "bob",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

---

### Accept or decline request

```txt
PATCH /friends/requests/:requestId
```

Request body:

```json
{
  "action": "ACCEPT"
}
```

or:

```json
{
  "action": "DECLINE"
}
```

Rules:

- only the receiver can accept or decline
- sender cannot accept their own sent request
- request must exist
- request must still be pending
- invalid action values are rejected by DTO validation

Accept response:

```json
{
  "friendshipId": 3,
  "status": "ACCEPTED",
  "updatedAt": "2026-05-09T08:39:25.870Z"
}
```

Decline response:

```json
{
  "message": "Friend request declined"
}
```

---

### List accepted friends

```txt
GET /friends
```

Returns accepted friendships where the authenticated user is either sender or receiver.

Example response for Alice:

```json
[
  {
    "friendshipId": 3,
    "friend": {
      "id": 12,
      "username": "bob",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

Example response for Bob:

```json
[
  {
    "friendshipId": 3,
    "friend": {
      "id": 11,
      "username": "alice",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

---

### Remove friend

```txt
DELETE /friends/:friendshipId
```

Rules:

- friendship must exist
- friendship must be accepted
- only one of the two participants can remove it
- pending requests cannot be removed through this endpoint

Success response:

```json
{
  "message": "Friend removed"
}
```

---

## Security notes

### Authentication

All Friends endpoints are protected by the existing global JWT guard.

No `@Public()` decorator is used.

---

### Sender spoofing protection

The client never sends `senderId`.

The sender is always taken from the authenticated JWT payload:

```ts
req.user.sub
```

This prevents a client from pretending to send a request as another user.

---

### Authorization

Implemented checks:

- only receiver can accept or decline a request
- sender cannot accept their own sent request
- only friendship participants can remove an accepted friendship
- users cannot remove someone else's friendship

---

### Validation

Implemented checks:

- invalid path IDs are rejected by `ParseIntPipe`
- invalid response actions are rejected by `@IsEnum(FriendRequestAction)`
- users cannot send friend requests to themselves
- target user must exist
- duplicate requests are blocked
- reverse duplicate requests are blocked
- already accepted friendships block new requests

---

### Private data exposure prevention

Friends endpoints return only the existing public user shape:

```txt
id
username
bio
avatar
wins
losses
draws
xp
```

They do not expose:

```txt
email
passwordHash
twoFactorSecret
twoFactorTempSecret
```

Prisma `select` is used so private fields are not fetched from the database in the first place.

---

### Race condition protection

The service checks for existing friendships before creating a new request.

The database also enforces uniqueness with:

```prisma
@@unique([userAId, userBId])
```

The service catches Prisma `P2002` errors to return a controlled conflict response if two simultaneous requests race each other.

---

### Resource exhaustion protection

Simple limits were added:

```txt
MAX_PENDING_FRIEND_REQUESTS = 50
MAX_FRIEND_RESULTS = 100
```

This prevents one user from creating unlimited pending outgoing requests and prevents list endpoints from returning unbounded result sets.

Full pagination and request cooldowns can be added later.

---

## Curl testing

### Clean local cookie files

```bash
rm -f alice.txt bob.txt
```

---

### Register Alice

```bash
curl -i -c alice.txt \
	-X POST http://localhost:1024/api/auth/register \
	-H "Content-Type: application/json" \
	-d '{"email":"alice@example.com","password":"Secret123","username":"alice"}'
```

Expected:

```txt
201 Created
```

---

### Register Bob

```bash
curl -i -c bob.txt \
	-X POST http://localhost:1024/api/auth/register \
	-H "Content-Type: application/json" \
	-d '{"email":"bob@example.com","password":"Secret123","username":"bob"}'
```

Expected:

```txt
201 Created
```

---

### Login Alice

```bash
curl -i -c alice.txt \
	-X POST http://localhost:1024/api/auth/login \
	-H "accept: */*" \
	-H "Content-Type: application/json" \
	-d '{"email":"alice@example.com","password":"Secret123"}'
```

Expected:

```txt
201 Created
Set-Cookie: access_token=...
```

---

### Login Bob

```bash
curl -i -c bob.txt \
	-X POST http://localhost:1024/api/auth/login \
	-H "accept: */*" \
	-H "Content-Type: application/json" \
	-d '{"email":"bob@example.com","password":"Secret123"}'
```

Expected:

```txt
201 Created
Set-Cookie: access_token=...
```

---

### Search Bob to confirm ID

```bash
curl -i -b alice.txt "http://localhost:1024/api/users?search=bob"
```

Expected:

```txt
200 OK
```

Use Bob's returned `id` in the next commands.

---

### Alice sends request to Bob

```bash
curl -i -b alice.txt \
	-X POST http://localhost:1024/api/friends/requests/12
```

Expected:

```txt
201 Created
```

Example response:

```json
{
  "requestId": 3,
  "status": "PENDING",
  "createdAt": "2026-05-09T08:38:08.789Z"
}
```

---

### Alice cannot send duplicate request

```bash
curl -i -b alice.txt \
	-X POST http://localhost:1024/api/friends/requests/12
```

Expected:

```txt
409 Conflict
```

---

### Bob cannot create reverse duplicate request

```bash
curl -i -b bob.txt \
	-X POST http://localhost:1024/api/friends/requests/11
```

Expected if Alice already has a pending request to Bob:

```txt
409 Conflict
```

---

### Alice cannot request herself

```bash
curl -i -b alice.txt \
	-X POST http://localhost:1024/api/friends/requests/11
```

Expected:

```txt
400 Bad Request
```

---

### Nonexistent user returns 404

```bash
curl -i -b alice.txt \
	-X POST http://localhost:1024/api/friends/requests/999999
```

Expected:

```txt
404 Not Found
```

---

### Unauthenticated request is blocked

```bash
curl -i \
	-X POST http://localhost:1024/api/friends/requests/12
```

Expected:

```txt
401 Unauthorized
```

---

### Bob sees incoming request

```bash
curl -i -b bob.txt \
	http://localhost:1024/api/friends/requests/incoming
```

Expected:

```txt
200 OK
```

Example response:

```json
[
  {
    "requestId": 3,
    "sender": {
      "id": 11,
      "username": "alice",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

---

### Alice does not see her sent request as incoming

```bash
curl -i -b alice.txt \
	http://localhost:1024/api/friends/requests/incoming
```

Expected:

```json
[]
```

---

### Alice sees outgoing request

```bash
curl -i -b alice.txt \
	http://localhost:1024/api/friends/requests/outgoing
```

Expected:

```txt
200 OK
```

---

### Bob accepts Alice request

```bash
curl -i -b bob.txt \
	-X PATCH http://localhost:1024/api/friends/requests/3 \
	-H "Content-Type: application/json" \
	-d '{"action":"ACCEPT"}'
```

Expected:

```txt
200 OK
```

Example response:

```json
{
  "friendshipId": 3,
  "status": "ACCEPTED",
  "updatedAt": "2026-05-09T08:39:25.870Z"
}
```

---

### Alice cannot accept her own sent request

```bash
curl -i -b alice.txt \
	-X PATCH http://localhost:1024/api/friends/requests/3 \
	-H "Content-Type: application/json" \
	-d '{"action":"ACCEPT"}'
```

Expected before Bob accepts:

```txt
403 Forbidden
```

---

### Invalid action is rejected

```bash
curl -i -b bob.txt \
	-X PATCH http://localhost:1024/api/friends/requests/3 \
	-H "Content-Type: application/json" \
	-d '{"action":"BANANA"}'
```

Expected:

```txt
400 Bad Request
```

---

### Alice sees Bob in friends list

```bash
curl -i -b alice.txt \
	http://localhost:1024/api/friends
```

Expected:

```txt
200 OK
```

Example response:

```json
[
  {
    "friendshipId": 3,
    "friend": {
      "id": 12,
      "username": "bob",
      "bio": "",
      "avatar": "/default.png",
      "wins": 0,
      "losses": 0,
      "draws": 0,
      "xp": 0
    },
    "createdAt": "2026-05-09T08:38:08.789Z"
  }
]
```

---

### Bob sees Alice in friends list

```bash
curl -i -b bob.txt \
	http://localhost:1024/api/friends
```

Expected:

```txt
200 OK
```

---

### Removing nonexistent friendship returns 404

```bash
curl -i -b alice.txt \
	-X DELETE http://localhost:1024/api/friends/999999
```

Expected:

```txt
404 Not Found
```

---

### Pending request cannot be removed as accepted friendship

```bash
curl -i -b alice.txt \
	-X DELETE http://localhost:1024/api/friends/4
```

Expected if request `4` is pending:

```txt
400 Bad Request
```

---

### Alice or Bob can remove accepted friendship

```bash
curl -i -b bob.txt \
	-X DELETE http://localhost:1024/api/friends/3
```

Expected:

```txt
200 OK
```

Response:

```json
{
  "message": "Friend removed"
}
```

---

### After removal, both lists are empty

```bash
curl -i -b alice.txt http://localhost:1024/api/friends
curl -i -b bob.txt http://localhost:1024/api/friends
```

Expected:

```json
[]
```

---

## Swagger testing

Open:

```txt
http://localhost:1024/api/api-docs
```

Checked:

- Friends tag appears
- send friend request endpoint appears
- incoming requests endpoint appears
- outgoing requests endpoint appears
- respond endpoint shows `ACCEPT` / `DECLINE`
- friends list endpoint appears
- remove friend endpoint appears

---

## Behavior verified

- Authenticated user can send a friend request
- Duplicate request returns `409 Conflict`
- Reverse duplicate request returns `409 Conflict`
- Self-request returns `400 Bad Request`
- Nonexistent user returns `404 Not Found`
- Unauthenticated request returns `401 Unauthorized`
- Receiver can see incoming request
- Sender can see outgoing request
- Sender cannot accept their own sent request
- Receiver can accept request
- Invalid action returns `400 Bad Request`
- Accepted friendship appears for both users
- Either participant can remove accepted friendship
- Pending request cannot be removed through unfriend endpoint
- After removal, both users no longer see the friendship
- No private user fields are exposed

---

## Limitations / future work

Possible follow-up issue:

```txt
[BACKEND][FRIENDS] Add friend request cooldown and paginated friends queries
```

Future improvements:

- add proper pagination query params for friends endpoints
- add cooldown/rate limiting for friend request creation
- add max accepted friends per user if needed
- add frontend friend buttons and pending requests panel
- add notification badge for incoming requests
- add WebSocket notifications when a request is received
- consider relationship status in user search results
- consider block system integration later

---

## Notes

This PR keeps frontend changes out of scope.

The current backend endpoints are enough for frontend integration using:

```txt
GET /users?search=<username>
GET /friends
GET /friends/requests/incoming
GET /friends/requests/outgoing
POST /friends/requests/:userId
PATCH /friends/requests/:requestId
DELETE /friends/:friendshipId
```

The frontend can combine these responses to decide whether to show:

```txt
Add
Pending
Accept
Friend
Self
```

---

Closes #268 