### PR TITLE
[BACK-FRONT] Final Achievement Logic & UI Polish

### DIFF
--- a/backend/src/modules/game/achievement/achievements.lists.ts
+++ b/backend/src/modules/game/achievement/achievements.lists.ts
@@ -6,6 +6,8 @@ export type AchievementKey =
     |   'WIN_5'
     |   'WIN_10'
     |   'WIN_50'
+    |   'GET_ALL'
+    
 
 export const ACHIEVEMENTS: Record<AchievementKey, { key: AchievementKey, displayName: string, description: string, iconName: string }> = {
 
@@ -16,5 +18,6 @@ export const ACHIEVEMENTS: Record<AchievementKey, { key: AchievementKey, display
   WIN_5: { key: 'WIN_5', displayName: 'High Five', description: 'Win a total of 5 matches.', iconName: "WIN_5_TROPHY" },
   WIN_10: { key: 'WIN_10', displayName: 'Double Digits', description: 'Win a total of 10 matches.', iconName: "WIN_10_TROPHY" },
   WIN_50: { key: 'WIN_50', displayName: 'Veteran', description: 'Win a total of 50 matches.', iconName: "WIN_50_TROPHY" },
+  GET_ALL: { key: 'GET_ALL', displayName: 'End Game', description: 'Complete all achievements', iconName: "GET_ALL_TROPHY" },
 
 } as const;

--- a/backend/src/modules/game/achievement/achievements.service.ts
+++ b/backend/src/modules/game/achievement/achievements.service.ts
@@ -27,7 +27,7 @@ export class AchievementsService {
   }
 
   async getAllAchievements() {
-    return Object.values(ACHIEVEMENTS)
+    return Object.values(ACHIEVEMENTS);
   }
 
   async getAchievements(userId: number) {
@@ -53,6 +53,22 @@ export class AchievementsService {
       };
     });
     return getInfoFromAchievements;
+  }
+
+  async checkAllAchievementsUnlocked(userId: number, tx?: Prisma.TransactionClient) {
+    const prisma = tx || this.prismaService;
+
+    const userAchievement = await prisma.userAchievement.count({
+      where: {
+        userId,
+        key: {
+          not: 'GET_ALL',
+        },
+      },
+    });
+    if (userAchievement >= Object.keys(ACHIEVEMENTS).length - 1) {
+      await this.unlockAchievement(userId, 'GET_ALL', tx);
+    }
   }
 
   async handleMatchAchievements(
@@ -96,5 +112,8 @@ export class AchievementsService {
           : result.player1Id;
       await this.unlockAchievement(loserId, 'LOSE_BY_TIME', tx);
     }
+
+    await this.checkAllAchievementsUnlocked(result.player1Id, tx);
+    await this.checkAllAchievementsUnlocked(result.player2Id, tx);
   }
 }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -321,8 +321,8 @@ export default function Profile() {
                     />
                   </div>
 
-                  <div className="absolute -top-10 scale-0 group-hover:scale-100 transition-all bg-black/90 p-2 rounded text-[10px] z-50 pointer-events-none">
-                    <p className="font-bold text-cyan-400">{ach.displayName}</p>
+                  <div className="absolute -top-10 scale-0 group-hover:scale-110 transition-all bg-black/90 p-2 rounded text-[10px] z-50 pointer-events-none">
+                    <p className="font-bold text-cyan-400">{ach.description}</p>
                   </div>
                 </div>
               );

--- a/frontend/src/type/achievements.types.ts
+++ b/frontend/src/type/achievements.types.ts
@@ -6,6 +6,7 @@ import {
   Skull,
   Crosshair,
   Infinity,
+  Crown,
 } from "lucide-react";
 
 export const ACHIEVEMENT_ICONS = {
@@ -16,6 +17,7 @@ export const ACHIEVEMENT_ICONS = {
   WIN_5_TROPHY: Crosshair,
   WIN_10_TROPHY: Skull,
   WIN_50_TROPHY: Infinity,
+  GET_ALL_TROPHY: Crown,
 } as const;
 
 export type IconKey = keyof typeof ACHIEVEMENT_ICONS


### PR DESCRIPTION
## Summary

Finalizes the achievement system by adding the ultimate "End Game" (Platinum) trophy and improving the user experience on the profile page. The backend automatically detects when all achievements are unlocked and awards the final trophy without any manual trigger.

---

## Files modified

| File | Description |
|------|-------------|
| `achievements.list.ts` | Added the `GET_ALL` constant — "End Game" trophy |
| `achievements.service.ts` | Added counting logic and end-of-match trigger |
| `Profile.tsx` | Updated tooltip display and hover animations |
| `achievements.types.ts` | Mapped the new `Crown` icon from Lucide-React |

---

## What was done

### 1. Backend — The 100% completion quest

- **"End Game" achievement:** Added the `GET_ALL` key to the achievement constants.
- **Unlock logic:** Implemented `checkAllAchievementsUnlocked`, which counts all earned achievements (excluding `GET_ALL` itself) and automatically awards the final trophy once every other achievement is validated.
- **Automation:** The check is now systematically triggered for both players at the end of every match via `handleMatchAchievements`.

### 2. Frontend — UI/UX improvements

- **Dynamic tooltips:** Hovering over an achievement on the profile page now displays its **description** instead of its name, giving the user better context.
- **Visual feedback:** Increased hover scale to `scale-110` for a smoother, more modern feel.
- **New icon:** Integrated the `Crown` icon from Lucide-React to represent the `GET_ALL` trophy.

---

## Why

- **Completion incentive:** Gives players a clear end goal and rewards 100% completion with a distinct Platinum-tier trophy.
- **Better UX:** Descriptions on hover are more informative than names alone — the user understands what each achievement means without leaving the page.
- **Clean automation:** The final trophy is awarded server-side with no extra client interaction needed.

---

## How to test

### Setup

```sh
make nuke
make setup
make up
```

---

### Seed shortcut — unlock most achievements instantly

A ready-to-use seed file is available in the **#database** channel on Discord. Copy and past it  on the already seed and run it to pre-populate your account with most achievements, so you only need to unlock the remaining ones manually.

This lets you reach the final trophy much faster without having to grind every achievement from scratch.

---

### Step-by-step validation

**1. Check the achievement list on your profile**

Navigate to your profile page and verify that the **"End Game"** trophy appears greyed out in the achievement list alongside all others.

**2. Unlock the remaining achievements by playing**

Play the match types needed to unlock whichever achievements are still missing after the seed. Refer to the table below:

| Key | Display name | How to trigger |
|-----|-------------|----------------|
| `FIRST_GAME` | First of all | Complete any match |
| `FIRST_WIN` | First Blood | Win a match |
| `DRAW_GAME` | Boring | Finish a match with a draw |
| `LOSE_BY_TIME` | Noob | Lose because the turn timer ran out |
| `WIN_5` | High Five | Win 5 matches (cumulative) |
| `WIN_10` | Double Digits | Win 10 matches (cumulative) |
| `WIN_50` | Veteran | Win 50 matches (cumulative) |
| `GET_ALL` | End Game | Unlock all other achievements |

**3. Verify the "End Game" trophy unlocks automatically**

Once the last missing achievement is earned, **"End Game"** should unlock on its own at the end of that match — no extra action required.

**4. Test the profile hover behaviour**

On the profile page, hover over any achievement icon and verify:
- The **description** is displayed in the tooltip (not the name).
- The icon scales up smoothly on hover (`scale-110`).
- The `Crown` icon is correctly displayed for the **"End Game"** trophy.