### PR TITLE
[FRIENDS][PRESENCE] Add realtime friend status and live social updates

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,16 +9,25 @@ import { PrismaModule } from './prisma/prisma.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { ChatModule } from './modules/chat/chat.modules';
 import { FriendsModule } from './friends/friends.module';
+import { PresenceModule } from './presence/presence.module';
 
 @Module({
-  imports: [UsersModule, PrismaModule, AuthModule, GameModule, ChatModule, FriendsModule],
-  controllers: [AppController],
-  providers: [
-    AppService,
-    {
-      provide: APP_GUARD,
-      useExisting: JwtAuthGuard,
-    },
-  ],
+imports: [
+	UsersModule,
+	PrismaModule,
+	AuthModule,
+	GameModule,
+	ChatModule,
+	FriendsModule,
+	PresenceModule,
+],
+controllers: [AppController],
+providers: [
+	AppService,
+	{
+	provide: APP_GUARD,
+	useExisting: JwtAuthGuard,
+	},
+],
 })
 export class AppModule {}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -135,9 +135,6 @@ export class AuthController {
 			sameSite: 'lax',
 			path: '/',
 		});
-		if (userId !== null) {
-			this.presenceService.disconnectUserSockets(userId);
-		}
 
 		res.clearCookie('2fa_pending', {
 			httpOnly: true,

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -16,6 +16,9 @@ import { Public } from './public.decorator';
 import type { AuthRequest } from './jwt-auth.guard';
 import { TwoFactorService } from './twofa.service';
 import { TwoFactorCodeDto } from './dto/twofa-code.dto';
+import { JwtService } from '@nestjs/jwt';
+import { PresenceService } from '../presence/presence.service';
+import type { JwtPayload } from './jwt-auth.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -23,6 +26,8 @@ export class AuthController {
 	constructor(
 		private readonly authService: AuthService,
 		private readonly twoFactorService: TwoFactorService,
+		private readonly jwtService: JwtService,
+		private readonly presenceService: PresenceService,
 	) {}
 
 	@Public()
@@ -109,13 +114,30 @@ export class AuthController {
 		description: 'Logout successful',
 	})
 	@Post('logout')
-	logout(@Res({ passthrough: true }) res: Response) {
+	async logout(
+		@Req() req: Request,
+		@Res({ passthrough: true }) res: Response,
+	) {
+		const token = req.cookies?.['access_token'];
+		let userId: number | null = null;
+
+		if (token) {
+			try {
+				const payload = await this.jwtService.verifyAsync<JwtPayload>(token);
+				userId = payload.sub;
+			} catch {
+				userId = null;
+			}
+		}
 		res.clearCookie('access_token', {
 			httpOnly: true,
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'lax',
 			path: '/',
 		});
+		if (userId !== null) {
+			this.presenceService.disconnectUserSockets(userId);
+		}
 
 		res.clearCookie('2fa_pending', {
 			httpOnly: true,
@@ -123,6 +145,9 @@ export class AuthController {
 			sameSite: 'lax',
 			path: '/',
 		});
+		if (userId !== null) {
+			this.presenceService.disconnectUserSockets(userId);
+		}
 
 		return { message: 'AUTH_LOGOUT_SUCCESS' };
 	}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { HttpModule } from '@nestjs/axios';
 import { PrismaModule } from '../prisma/prisma.module';
@@ -8,6 +8,7 @@ import { JwtAuthGuard } from './jwt-auth.guard';
 import { OAuthController } from './oauth.controller';
 import { OAuthService } from './oauth.service';
 import { TwoFactorService } from './twofa.service';
+import { PresenceModule } from '../presence/presence.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { TwoFactorService } from './twofa.service';
     }),
     PrismaModule,
     HttpModule,
+	forwardRef(() => PresenceModule)
   ],
   controllers: [AuthController, OAuthController],
   providers: [AuthService, OAuthService, TwoFactorService, JwtAuthGuard],

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -97,4 +97,9 @@ export class FriendsController {
 			friendshipId,
 		);
 	}
+	@ApiOperation({ summary: 'List accepted friends statuses' })
+	@Get('status')
+	getFriendsStatus(@Req() req: AuthRequest) {
+		return this.friendsService.getFriendsStatus(req.user.sub);
+	}
 }

--- a/backend/src/friends/friends.module.ts
+++ b/backend/src/friends/friends.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { FriendsController } from './friends.controller';
 import { FriendsService } from './friends.service';
+import { PresenceModule } from '../presence/presence.module';
 
 @Module({
-	imports: [PrismaModule],
+	imports: [PrismaModule, PresenceModule],
 	controllers: [FriendsController],
 	providers: [FriendsService],
 })

--- a/backend/src/friends/friends.module.ts
+++ b/backend/src/friends/friends.module.ts
@@ -6,7 +6,7 @@ import { PresenceModule } from '../presence/presence.module';
 import { GameModule } from '../modules/game/game.module';
 
 @Module({
-	imports: [PrismaModule, forwardRef(() =>PresenceModule), GameModule],
+	imports: [PrismaModule, forwardRef(() =>PresenceModule),forwardRef(() => GameModule)],
 	controllers: [FriendsController],
 	providers: [FriendsService],
 	exports: [FriendsService],

--- a/backend/src/friends/friends.module.ts
+++ b/backend/src/friends/friends.module.ts
@@ -3,9 +3,10 @@ import { PrismaModule } from '../prisma/prisma.module';
 import { FriendsController } from './friends.controller';
 import { FriendsService } from './friends.service';
 import { PresenceModule } from '../presence/presence.module';
+import { GameModule } from '../modules/game/game.module';
 
 @Module({
-	imports: [PrismaModule, forwardRef(() =>PresenceModule)],
+	imports: [PrismaModule, forwardRef(() =>PresenceModule), GameModule],
 	controllers: [FriendsController],
 	providers: [FriendsService],
 	exports: [FriendsService],

--- a/backend/src/friends/friends.module.ts
+++ b/backend/src/friends/friends.module.ts
@@ -1,12 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { FriendsController } from './friends.controller';
 import { FriendsService } from './friends.service';
 import { PresenceModule } from '../presence/presence.module';
 
 @Module({
-	imports: [PrismaModule, PresenceModule],
+	imports: [PrismaModule, forwardRef(() =>PresenceModule)],
 	controllers: [FriendsController],
 	providers: [FriendsService],
+	exports: [FriendsService],
 })
 export class FriendsModule {}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -2,6 +2,8 @@ import {
 	BadRequestException,
 	ConflictException,
 	Injectable,
+	Inject,
+	forwardRef,
 	NotFoundException,
 	ForbiddenException,
 } from '@nestjs/common';
@@ -16,6 +18,7 @@ import { GameService } from '../modules/game/game.service';
 export class FriendsService {
 	constructor(
 		private readonly prisma: PrismaService,
+		@Inject(forwardRef(() => PresenceService))
 		private readonly presenceService: PresenceService,
 		private readonly gameService: GameService,
 	) {}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -94,6 +94,8 @@ export class FriendsService {
 				},
 			});
 
+			this.presenceService.emitFriendsUpdated([senderId, receiverId]);
+
 			return {
 				requestId: request.id,
 				status: request.status,
@@ -192,6 +194,7 @@ export class FriendsService {
 			where: { id: requestId },
 			select: {
 				id: true,
+				senderId: true,
 				receiverId: true,
 				status: true,
 			},
@@ -216,6 +219,8 @@ export class FriendsService {
 				where: { id: requestId },
 			});
 
+			this.presenceService.emitFriendsUpdated([userId, request.senderId]);
+
 			return {
 				message: 'FRIEND_REQUEST_DECLINED',
 			};
@@ -232,6 +237,8 @@ export class FriendsService {
 				updatedAt: true,
 			},
 		});
+
+		this.presenceService.emitFriendsUpdated([userId, request.senderId]);
 
 		return {
 			friendshipId: updatedRequest.id,
@@ -326,6 +333,11 @@ export class FriendsService {
 		await this.prisma.friend.delete({
 			where: { id: friendshipId },
 		});
+
+		this.presenceService.emitFriendsUpdated([
+			friendship.senderId,
+			friendship.receiverId,
+		]);
 
 		return {
 			message: 'FRIEND_REMOVED_SUCCESS',

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -355,4 +355,26 @@ export class FriendsService {
 			};
 		});
 	}
+
+	async getAcceptedFriendIds(userId: number): Promise<number[]> {
+		const friendships = await this.prisma.friend.findMany({
+			where: {
+				status: FriendStatus.ACCEPTED,
+				OR: [
+					{ senderId: userId },
+					{ receiverId: userId },
+				],
+			},
+			select: {
+				senderId: true,
+				receiverId: true,
+			},
+		});
+
+		return friendships.map((friendship) =>
+			friendship.senderId === userId
+				? friendship.receiverId
+				: friendship.senderId,
+		);
+	}
 }

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -351,10 +351,15 @@ export class FriendsService {
 					? friendship.receiverId
 					: friendship.senderId;
 
+			const online = this.presenceService.isUserOnline(friendId);
+
 			return {
 				userId: friendId,
-				online: this.presenceService.isUserOnline(friendId),
-				inGame: this.gameService.isUserInGame(friendId),
+				online,
+				inGame: online && this.gameService.isUserInGame(friendId),
+				activity: online
+					? this.gameService.getUserGameActivity(friendId)
+					: 'offline',
 			};
 		});
 	}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -10,11 +10,14 @@ import { PrismaService } from '../prisma/prisma.service';
 import { FriendRequestAction } from './dto/respond-friend-request.dto';
 import { MAX_PENDING_FRIEND_REQUESTS, MAX_FRIEND_RESULTS} from './friends.constants';
 import { PresenceService } from '../presence/presence.service';
+import { GameService } from '../modules/game/game.service';
 
 @Injectable()
 export class FriendsService {
-	constructor(private readonly prisma: PrismaService,
+	constructor(
+		private readonly prisma: PrismaService,
 		private readonly presenceService: PresenceService,
+		private readonly gameService: GameService,
 	) {}
 
 	async sendFriendRequest(senderId: number, receiverId: number) {
@@ -351,7 +354,7 @@ export class FriendsService {
 			return {
 				userId: friendId,
 				online: this.presenceService.isUserOnline(friendId),
-				inGame: false,
+				inGame: this.gameService.isUserInGame(friendId),
 			};
 		});
 	}

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -9,10 +9,13 @@ import { FriendStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { FriendRequestAction } from './dto/respond-friend-request.dto';
 import { MAX_PENDING_FRIEND_REQUESTS, MAX_FRIEND_RESULTS} from './friends.constants';
+import { PresenceService } from '../presence/presence.service';
 
 @Injectable()
 export class FriendsService {
-	constructor(private readonly prisma: PrismaService) {}
+	constructor(private readonly prisma: PrismaService,
+		private readonly presenceService: PresenceService,
+	) {}
 
 	async sendFriendRequest(senderId: number, receiverId: number) {
 		if (senderId === receiverId) {
@@ -321,5 +324,35 @@ export class FriendsService {
 		return {
 			message: 'FRIEND_REMOVED_SUCCESS',
 		};
+	}
+
+	async getFriendsStatus(userId: number) {
+		const friendships = await this.prisma.friend.findMany({
+			where: {
+				status: FriendStatus.ACCEPTED,
+				OR: [
+					{ senderId: userId },
+					{ receiverId: userId },
+				],
+			},
+			take: MAX_FRIEND_RESULTS,
+			select: {
+				senderId: true,
+				receiverId: true,
+			},
+		});
+
+		return friendships.map((friendship) => {
+			const friendId =
+				friendship.senderId === userId
+					? friendship.receiverId
+					: friendship.senderId;
+
+			return {
+				userId: friendId,
+				online: this.presenceService.isUserOnline(friendId),
+				inGame: false,
+			};
+		});
 	}
 }

--- a/backend/src/modules/game/game.controller.ts
+++ b/backend/src/modules/game/game.controller.ts
@@ -9,13 +9,15 @@ import {
   	ApiResponse,
   	ApiCookieAuth,
 } from '@nestjs/swagger';
+import { PresenceService } from 'src/presence/presence.service';
 
 @ApiTags('Game')
 @Controller('game')
 export class GameController {
   	constructor(
     	private readonly gameService: GameService,
-    	private readonly usersService: UsersService
+    	private readonly usersService: UsersService,
+    	private readonly presenceService: PresenceService,
   	) {}
 
 @ApiCookieAuth()
@@ -26,6 +28,7 @@ export class GameController {
 async createGame(@Req() req: AuthRequest) {
     const user = await this.usersService.getUser(req.user.sub);
     const gameId = this.gameService.createGame(user);
+    await this.presenceService.emitFriendStatusChange(req.user.sub);
     return { gameId };
 	}
 
@@ -63,9 +66,13 @@ getGame(@Param('id') gameId: string) {
 @ApiResponse({ status: 401, description: 'Not authenticated' })
 @ApiResponse({ status: 404, description: 'Game not found' })
 @Post(':id/leave')
-leaveGame(@Param('id') gameId: string, @Req() req: AuthRequest) {
-    return this.gameService.leaveGame(gameId, req.user.sub);
-	}
+async leaveGame(@Param('id') gameId: string, @Req() req: AuthRequest) {
+	const result = this.gameService.leaveGame(gameId, req.user.sub);
+
+	await this.presenceService.emitFriendStatusChange(req.user.sub);
+
+	return result;
+}
 
 @ApiCookieAuth()
 @ApiOperation({ summary: 'Get finished game history by game ID' })

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -14,6 +14,7 @@ import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import { UseGuards } from '@nestjs/common';
 import { UsersService } from 'src/users/users.service';
 import type { AuthSocket } from 'src/auth/jwt-auth.guard';
+import { PresenceService } from '../../presence/presence.service';
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
 const parts = rawOrigins.split(',');
@@ -43,6 +44,7 @@ export class GameGateway implements OnGatewayDisconnect {
   constructor(
     private readonly gameService: GameService,
     private readonly usersService: UsersService,
+    private readonly presenceService: PresenceService,
   ) {}
 
   private getTimerKey(gameId: string, role: 'X' | 'O') {
@@ -219,12 +221,14 @@ export class GameGateway implements OnGatewayDisconnect {
       client.data.currentGameId = body.gameId;
 
       this.emitGameUpdate(body.gameId, game);
+	  await this.presenceService.emitFriendStatusChange(userId);
       client.emit('joined_as', { role });
     } catch (error) {
       client.emit('game_error', {
         message: error instanceof Error ? error.message : 'Unknown error',
       });
     }
+
   }
 
   @SubscribeMessage('play_move')

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -71,6 +71,17 @@ export class GameGateway implements OnGatewayDisconnect {
         .then((result) => {
           if (result) {
             this.emitGameUpdate(gameId, result.game);
+            if (result.game.playerProfiles.X?.id) {
+                this.presenceService.emitFriendStatusChange(
+                    result.game.playerProfiles.X.id,
+                );
+            }
+
+            if (result.game.playerProfiles.O?.id) {
+                this.presenceService.emitFriendStatusChange(
+                    result.game.playerProfiles.O.id,
+                );
+            }
           }
         })
         .catch((error) => {
@@ -108,6 +119,17 @@ export class GameGateway implements OnGatewayDisconnect {
         .then((result) => {
           if (result) {
             this.emitGameUpdate(gameId, result);
+            if (result.playerProfiles.X?.id) {
+                this.presenceService.emitFriendStatusChange(
+                    result.playerProfiles.X.id,
+                );
+            }
+
+            if (result.playerProfiles.O?.id) {
+                this.presenceService.emitFriendStatusChange(
+                    result.playerProfiles.O.id,
+                );
+            }
           }
         })
         .catch((error) => {
@@ -221,7 +243,17 @@ export class GameGateway implements OnGatewayDisconnect {
       client.data.currentGameId = body.gameId;
 
       this.emitGameUpdate(body.gameId, game);
-	  await this.presenceService.emitFriendStatusChange(userId);
+      if (game.playerProfiles.X?.id) {
+        await this.presenceService.emitFriendStatusChange(
+            game.playerProfiles.X.id,
+        );
+    }
+
+    if (game.playerProfiles.O?.id) {
+        await this.presenceService.emitFriendStatusChange(
+            game.playerProfiles.O.id,
+        );
+    }
       client.emit('joined_as', { role });
     } catch (error) {
       client.emit('game_error', {
@@ -292,6 +324,7 @@ export class GameGateway implements OnGatewayDisconnect {
         await client.leave(body.gameId);
         if (client.data.currentGameId === body.gameId) {
           delete client.data.currentGameId;
+          await this.presenceService.emitFriendStatusChange(userId);
         }
         return;
       }
@@ -300,6 +333,7 @@ export class GameGateway implements OnGatewayDisconnect {
         await client.leave(body.gameId);
         if (client.data.currentGameId === body.gameId) {
           delete client.data.currentGameId;
+          await this.presenceService.emitFriendStatusChange(userId);
         }
       }
     } catch (error) {

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -245,6 +245,13 @@ export class GameGateway implements OnGatewayDisconnect {
         body.c,
       );
       this.emitGameUpdate(body.gameId, newGameState);
+      if (newGameState.playerProfiles.X?.id) {
+            await this.presenceService.emitFriendStatusChange(newGameState.playerProfiles.X.id);
+        }
+
+        if (newGameState.playerProfiles.O?.id) {
+            await this.presenceService.emitFriendStatusChange(newGameState.playerProfiles.O.id);
+        }
       return newGameState;
     } catch (error) {
       client.emit('game_error', {

--- a/backend/src/modules/game/game.module.ts
+++ b/backend/src/modules/game/game.module.ts
@@ -18,6 +18,6 @@ import { AchievementsService } from './achievement/achievements.service';
   ],
   providers: [GameService, GameGateway, MatchesService, AchievementsService],
   controllers: [GameController],
-  exports: [MatchesService, AchievementsService],
+  exports: [MatchesService, AchievementsService, GameService],
 })
 export class GameModule {}

--- a/backend/src/modules/game/game.module.ts
+++ b/backend/src/modules/game/game.module.ts
@@ -7,11 +7,13 @@ import { PrismaModule } from 'src/prisma/prisma.module';
 import { UsersModule } from 'src/users/users.module';
 import { JwtModule } from '@nestjs/jwt';
 import { AchievementsService } from './achievement/achievements.service';
+import { PresenceModule } from '../../presence/presence.module';
 
 @Module({
   imports: [
     PrismaModule,
     forwardRef(() => UsersModule),
+    forwardRef(() => PresenceModule),
     JwtModule.register({
       secret: process.env.JWT_SECRET,
     }),

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -98,6 +98,19 @@ export class GameService {
     };
   }
 
+  isUserInGame(userId: number): boolean {
+    const active = this.findActiveGameByUserId(userId);
+
+      if (!active) {
+        return false;
+      }
+
+    const [, game] = active;
+
+    return game.status === 'playing';
+  }
+
+
   joinGame(
     gameId: string,
     socketId: string,

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -110,6 +110,26 @@ export class GameService {
     return game.status === 'playing';
   }
 
+  getUserGameActivity(userId: number): 'available' | 'waiting' | 'playing' {
+    const active = this.findActiveGameByUserId(userId);
+
+    if (!active) {
+        return 'available';
+    }
+
+    const [, game] = active;
+
+    if (game.status === 'waiting') {
+        return 'waiting';
+    }
+
+    if (game.status === 'playing') {
+        return 'playing';
+    }
+
+    return 'available';
+}
+
 
   joinGame(
     gameId: string,

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -335,7 +335,7 @@ export class GameService {
 
     // playing
     if (game.status === 'playing')
-      throw new BadRequestException('Cant delete game pplaying');
+      throw new BadRequestException('ERR_GAME_CANT_LEAVE_PLAYING');
 
     if (game.status === 'waiting' && role === 'X') {
       this.activeGame.delete(gameId);

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -35,11 +35,8 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 	async handleConnection(client: AuthSocket) {
 		const user = await this.getUserFromSocket(client);
 
-		console.log('[PresenceGateway] socket connected:', client.id);
-		console.log('[PresenceGateway] authenticated user:', user?.sub);
 
 		if (!user) {
-			console.log('[PresenceGateway] missing authenticated user');
 			client.disconnect();
 			return;
 		}
@@ -59,11 +56,9 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 			await this.emitFriendStatusChange(user.sub, true);
 		}
 
-		console.log('[PresenceGateway] user connected to presence service');
 	}
 
 	async handleDisconnect(client: AuthSocket) {
-		console.log('[PresenceGateway] socket disconnected:', client.id);
 
 		const result = this.presenceService.disconnectSocket(client.id);
 

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -124,10 +124,15 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 	}
 
 	private buildFriendStatus(userId: number) {
+		const online = this.presenceService.isUserOnline(userId);
+
 		return {
 			userId,
-			online: this.presenceService.isUserOnline(userId),
-			inGame: this.gameService.isUserInGame(userId),
+			online,
+			inGame: online && this.gameService.isUserInGame(userId),
+			activity: online
+				? this.gameService.getUserGameActivity(userId)
+				: 'offline',
 		};
 	}
 }

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -1,0 +1,46 @@
+import {
+	OnGatewayConnection,
+	OnGatewayDisconnect,
+	WebSocketGateway,
+} from '@nestjs/websockets';
+import { UseGuards } from '@nestjs/common';
+import type { AuthSocket } from '../auth/jwt-auth.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PresenceService } from './presence.service';
+
+const rawOrigins = process.env.CORS_ORIGINS ?? '';
+const allowedOrigins = rawOrigins
+	.split(',')
+	.map((origin) => origin.trim())
+	.filter((origin) => origin !== '');
+
+@WebSocketGateway({
+	cors: {
+		origin: allowedOrigins,
+		credentials: true,
+	},
+})
+
+export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect {
+	constructor(private readonly presenceService: PresenceService) {}
+
+	handleConnection(client: AuthSocket) {
+		const userId = client.data.user?.sub;
+		console.log('[PresenceGateway] socket connected:', client.id);
+		console.log('[PresenceGateway] authenticated user:', userId);
+
+		if (!userId) {
+			console.log('[PresenceGateway] missing authenticated user');
+			client.disconnect();
+			return;
+		}
+
+		this.presenceService.connectUser(userId, client.id);
+		console.log('[PresenceGateway] user connected to presence service');
+	}
+
+	handleDisconnect(client: AuthSocket) {
+		console.log('[PresenceGateway] socket disconnected:', client.id);
+		this.presenceService.disconnectSocket(client.id);
+	}
+}

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -45,12 +45,17 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		}
 
 		client.data.user = user;
-		const becameOnline = this.presenceService.connectUser(
+		const connection = this.presenceService.connectUser(
 			user.sub,
 			client.id,
 		);
 
-		if (becameOnline) {
+		if (!connection.connected) {
+			client.disconnect();
+			return;
+		}
+
+		if (connection.wasOffline) {
 			await this.emitFriendStatusChange(user.sub, true);
 		}
 

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -1,15 +1,15 @@
 import {
+	OnGatewayInit,
 	OnGatewayConnection,
 	OnGatewayDisconnect,
 	WebSocketGateway,
+	WebSocketServer,
 } from '@nestjs/websockets';
 import { JwtService } from '@nestjs/jwt';
 import type { AuthSocket, JwtPayload } from '../auth/jwt-auth.guard';
 import { PresenceService } from './presence.service';
-import { FriendsService } from '../friends/friends.service';
 import { Server } from 'socket.io';
-import { WebSocketServer } from '@nestjs/websockets';
-import { GameService } from '../modules/game/game.service';
+
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
 const allowedOrigins = rawOrigins
@@ -23,16 +23,20 @@ const allowedOrigins = rawOrigins
 		credentials: true,
 	},
 })
-export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class PresenceGateway
+	implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
+{
 	constructor(
 		private readonly presenceService: PresenceService,
 		private readonly jwtService: JwtService,
-		private readonly friendsService: FriendsService,
-		private readonly gameService: GameService,
 	) {}
 
 	@WebSocketServer()
 	server: Server;
+
+	afterInit() {
+		this.presenceService.setServer(this.server);
+	}
 
 	async handleConnection(client: AuthSocket) {
 		const user = await this.getUserFromSocket(client);
@@ -55,7 +59,7 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		}
 
 		if (connection.wasOffline) {
-			await this.emitFriendStatusChange(user.sub);
+			await this.presenceService.emitFriendStatusChange(user.sub);
 		}
 
 	}
@@ -68,7 +72,7 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 			return;
 		}
 
-		await this.emitFriendStatusChange(result.userId);
+		await this.presenceService.emitFriendStatusChange(result.userId);
 	}
 
 	private async getUserFromSocket(client: AuthSocket): Promise<JwtPayload | null> {
@@ -108,31 +112,4 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		return null;
 	}
 
-	private async emitFriendStatusChange(userId: number) {
-		const friendIds = await this.friendsService.getAcceptedFriendIds(userId);
-
-		for (const friendId of friendIds) {
-			const socketIds = this.presenceService.getUserSocketIds(friendId);
-
-			for (const socketId of socketIds) {
-				this.server.to(socketId).emit(
-					'friend_status_changed',
-					this.buildFriendStatus(userId),
-				);
-			}
-		}
-	}
-
-	private buildFriendStatus(userId: number) {
-		const online = this.presenceService.isUserOnline(userId);
-
-		return {
-			userId,
-			online,
-			inGame: online && this.gameService.isUserInGame(userId),
-			activity: online
-				? this.gameService.getUserGameActivity(userId)
-				: 'offline',
-		};
-	}
 }

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -6,6 +6,9 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import type { AuthSocket, JwtPayload } from '../auth/jwt-auth.guard';
 import { PresenceService } from './presence.service';
+import { FriendsService } from '../friends/friends.service';
+import { Server } from 'socket.io';
+import { WebSocketServer } from '@nestjs/websockets';
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
 const allowedOrigins = rawOrigins
@@ -23,7 +26,11 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 	constructor(
 		private readonly presenceService: PresenceService,
 		private readonly jwtService: JwtService,
+		private readonly friendsService: FriendsService,
 	) {}
+
+	@WebSocketServer()
+	server: Server;
 
 	async handleConnection(client: AuthSocket) {
 		const user = await this.getUserFromSocket(client);
@@ -38,15 +45,28 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		}
 
 		client.data.user = user;
-		this.presenceService.connectUser(user.sub, client.id);
+		const becameOnline = this.presenceService.connectUser(
+			user.sub,
+			client.id,
+		);
+
+		if (becameOnline) {
+			await this.emitFriendStatusChange(user.sub, true);
+		}
 
 		console.log('[PresenceGateway] user connected to presence service');
 	}
 
-	handleDisconnect(client: AuthSocket) {
+	async handleDisconnect(client: AuthSocket) {
 		console.log('[PresenceGateway] socket disconnected:', client.id);
 
-		this.presenceService.disconnectSocket(client.id);
+		const result = this.presenceService.disconnectSocket(client.id);
+
+		if (!result || !result.isOffline) {
+			return;
+		}
+
+		await this.emitFriendStatusChange(result.userId, false);
 	}
 
 	private async getUserFromSocket(client: AuthSocket): Promise<JwtPayload | null> {
@@ -84,5 +104,24 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		}
 
 		return null;
+	}
+
+	private async emitFriendStatusChange(
+		userId: number,
+		online: boolean,
+	) {
+		const friendIds = await this.friendsService.getAcceptedFriendIds(userId);
+
+		for (const friendId of friendIds) {
+			const socketIds = this.presenceService.getUserSocketIds(friendId);
+
+			for (const socketId of socketIds) {
+				this.server.to(socketId).emit('friend_status_changed', {
+					userId,
+					online,
+					inGame: false,
+				});
+			}
+		}
 	}
 }

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -9,6 +9,7 @@ import { PresenceService } from './presence.service';
 import { FriendsService } from '../friends/friends.service';
 import { Server } from 'socket.io';
 import { WebSocketServer } from '@nestjs/websockets';
+import { GameService } from '../modules/game/game.service';
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
 const allowedOrigins = rawOrigins
@@ -27,6 +28,7 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		private readonly presenceService: PresenceService,
 		private readonly jwtService: JwtService,
 		private readonly friendsService: FriendsService,
+		private readonly gameService: GameService,
 	) {}
 
 	@WebSocketServer()
@@ -53,7 +55,7 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		}
 
 		if (connection.wasOffline) {
-			await this.emitFriendStatusChange(user.sub, true);
+			await this.emitFriendStatusChange(user.sub);
 		}
 
 	}
@@ -66,7 +68,7 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 			return;
 		}
 
-		await this.emitFriendStatusChange(result.userId, false);
+		await this.emitFriendStatusChange(result.userId);
 	}
 
 	private async getUserFromSocket(client: AuthSocket): Promise<JwtPayload | null> {
@@ -106,22 +108,26 @@ export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect
 		return null;
 	}
 
-	private async emitFriendStatusChange(
-		userId: number,
-		online: boolean,
-	) {
+	private async emitFriendStatusChange(userId: number) {
 		const friendIds = await this.friendsService.getAcceptedFriendIds(userId);
 
 		for (const friendId of friendIds) {
 			const socketIds = this.presenceService.getUserSocketIds(friendId);
 
 			for (const socketId of socketIds) {
-				this.server.to(socketId).emit('friend_status_changed', {
-					userId,
-					online,
-					inGame: false,
-				});
+				this.server.to(socketId).emit(
+					'friend_status_changed',
+					this.buildFriendStatus(userId),
+				);
 			}
 		}
+	}
+
+	private buildFriendStatus(userId: number) {
+		return {
+			userId,
+			online: this.presenceService.isUserOnline(userId),
+			inGame: this.gameService.isUserInGame(userId),
+		};
 	}
 }

--- a/backend/src/presence/presence.gateway.ts
+++ b/backend/src/presence/presence.gateway.ts
@@ -3,9 +3,8 @@ import {
 	OnGatewayDisconnect,
 	WebSocketGateway,
 } from '@nestjs/websockets';
-import { UseGuards } from '@nestjs/common';
-import type { AuthSocket } from '../auth/jwt-auth.guard';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { JwtService } from '@nestjs/jwt';
+import type { AuthSocket, JwtPayload } from '../auth/jwt-auth.guard';
 import { PresenceService } from './presence.service';
 
 const rawOrigins = process.env.CORS_ORIGINS ?? '';
@@ -20,27 +19,70 @@ const allowedOrigins = rawOrigins
 		credentials: true,
 	},
 })
-
 export class PresenceGateway implements OnGatewayConnection, OnGatewayDisconnect {
-	constructor(private readonly presenceService: PresenceService) {}
+	constructor(
+		private readonly presenceService: PresenceService,
+		private readonly jwtService: JwtService,
+	) {}
 
-	handleConnection(client: AuthSocket) {
-		const userId = client.data.user?.sub;
+	async handleConnection(client: AuthSocket) {
+		const user = await this.getUserFromSocket(client);
+
 		console.log('[PresenceGateway] socket connected:', client.id);
-		console.log('[PresenceGateway] authenticated user:', userId);
+		console.log('[PresenceGateway] authenticated user:', user?.sub);
 
-		if (!userId) {
+		if (!user) {
 			console.log('[PresenceGateway] missing authenticated user');
 			client.disconnect();
 			return;
 		}
 
-		this.presenceService.connectUser(userId, client.id);
+		client.data.user = user;
+		this.presenceService.connectUser(user.sub, client.id);
+
 		console.log('[PresenceGateway] user connected to presence service');
 	}
 
 	handleDisconnect(client: AuthSocket) {
 		console.log('[PresenceGateway] socket disconnected:', client.id);
+
 		this.presenceService.disconnectSocket(client.id);
+	}
+
+	private async getUserFromSocket(client: AuthSocket): Promise<JwtPayload | null> {
+		const token = this.extractAccessToken(client);
+
+		if (!token) {
+			return null;
+		}
+
+		try {
+			return await this.jwtService.verifyAsync<JwtPayload>(token);
+		} catch {
+			return null;
+		}
+	}
+
+	private extractAccessToken(client: AuthSocket): string | null {
+		const rawCookies = client.handshake.headers.cookie;
+
+		if (!rawCookies) {
+			return null;
+		}
+
+		for (const cookie of rawCookies.split(';')) {
+			const [key, ...valueParts] = cookie.trim().split('=');
+			const value = valueParts.join('=');
+
+			if (key === 'access_token' && value) {
+				try {
+					return decodeURIComponent(value);
+				} catch {
+					return null;
+				}
+			}
+		}
+
+		return null;
 	}
 }

--- a/backend/src/presence/presence.module.ts
+++ b/backend/src/presence/presence.module.ts
@@ -3,9 +3,10 @@ import { AuthModule } from '../auth/auth.module';
 import { PresenceGateway } from './presence.gateway';
 import { PresenceService } from './presence.service';
 import { FriendsModule } from '../friends/friends.module';
+import { GameModule } from '../modules/game/game.module';
 
 @Module({
-	imports: [AuthModule, forwardRef(() => FriendsModule)],
+	imports: [AuthModule, forwardRef(() => FriendsModule), GameModule],
 	providers: [PresenceGateway, PresenceService],
 	exports: [PresenceService],
 })

--- a/backend/src/presence/presence.module.ts
+++ b/backend/src/presence/presence.module.ts
@@ -10,6 +10,7 @@ import { GameModule } from '../modules/game/game.module';
 		AuthModule,
 		forwardRef(() => FriendsModule),
 		forwardRef(() => GameModule),
+		forwardRef(() => AuthModule)
 	],
 	providers: [PresenceGateway, PresenceService],
 	exports: [PresenceService],

--- a/backend/src/presence/presence.module.ts
+++ b/backend/src/presence/presence.module.ts
@@ -1,10 +1,11 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { PresenceGateway } from './presence.gateway';
 import { PresenceService } from './presence.service';
+import { FriendsModule } from '../friends/friends.module';
 
 @Module({
-	imports: [AuthModule],
+	imports: [AuthModule, forwardRef(() => FriendsModule)],
 	providers: [PresenceGateway, PresenceService],
 	exports: [PresenceService],
 })

--- a/backend/src/presence/presence.module.ts
+++ b/backend/src/presence/presence.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PresenceGateway } from './presence.gateway';
+import { PresenceService } from './presence.service';
+
+@Module({
+	imports: [AuthModule],
+	providers: [PresenceGateway, PresenceService],
+	exports: [PresenceService],
+})
+export class PresenceModule {}

--- a/backend/src/presence/presence.module.ts
+++ b/backend/src/presence/presence.module.ts
@@ -6,7 +6,11 @@ import { FriendsModule } from '../friends/friends.module';
 import { GameModule } from '../modules/game/game.module';
 
 @Module({
-	imports: [AuthModule, forwardRef(() => FriendsModule), GameModule],
+	imports: [
+		AuthModule,
+		forwardRef(() => FriendsModule),
+		forwardRef(() => GameModule),
+	],
 	providers: [PresenceGateway, PresenceService],
 	exports: [PresenceService],
 })

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PresenceService {
+	private readonly onlineUsers = new Map<number, Set<string>>();
+	private readonly usersBySocket = new Map<string, number>();
+
+	connectUser(userId: number, socketId: string): boolean {
+		const sockets = this.onlineUsers.get(userId) ?? new Set<string>();
+		const wasOffline = sockets.size === 0;
+
+		sockets.add(socketId);
+		this.onlineUsers.set(userId, sockets);
+		this.usersBySocket.set(socketId, userId);
+
+		return wasOffline;
+	}
+
+	disconnectSocket(socketId: string): { userId: number; isOffline: boolean } | null {
+		const userId = this.usersBySocket.get(socketId);
+
+		if (userId === undefined) {
+			return null;
+		}
+
+		this.usersBySocket.delete(socketId);
+
+		const sockets = this.onlineUsers.get(userId);
+
+		if (!sockets) {
+			return {
+				userId,
+				isOffline: true,
+			};
+		}
+
+		sockets.delete(socketId);
+
+		if (sockets.size === 0) {
+			this.onlineUsers.delete(userId);
+
+			return {
+				userId,
+				isOffline: true,
+			};
+		}
+
+		return {
+			userId,
+			isOffline: false,
+		};
+	}
+
+	isUserOnline(userId: number): boolean {
+		return this.onlineUsers.has(userId);
+	}
+}

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -1,12 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { Server } from 'socket.io';
+import { FriendsService } from '../friends/friends.service';
+import { GameService } from '../modules/game/game.service';
 
 const MAX_PRESENCE_SOCKETS_PER_USER = 20;
 
 @Injectable()
 export class PresenceService {
+	constructor(
+		@Inject(forwardRef(() => FriendsService))
+		private readonly friendsService: FriendsService,
+
+		private readonly gameService: GameService,
+	) {}
 	private readonly onlineUsers = new Map<number, Set<string>>();
 	private readonly usersBySocket = new Map<string, number>();
+	private server: Server | null = null;
 
+	setServer(server: Server) {
+		this.server = server;
+	}
 	connectUser(userId: number, socketId: string): { connected: boolean; wasOffline: boolean } {
 		const sockets = this.onlineUsers.get(userId) ?? new Set<string>();
 
@@ -76,5 +89,36 @@ export class PresenceService {
 		}
 
 		return [...sockets];
+	}
+
+	async emitFriendStatusChange(userId: number) {
+		const friendIds = await this.friendsService.getAcceptedFriendIds(userId);
+
+		for (const friendId of friendIds) {
+			const socketIds = this.getUserSocketIds(friendId)
+
+			for (const socketId of socketIds) {
+				if (!this.server) {
+					return;
+				}
+				this.server.to(socketId).emit(
+					'friend_status_changed',
+					this.buildFriendStatus(userId),
+				);
+			}
+		}
+	}
+
+	private buildFriendStatus(userId: number) {
+		const online = this.isUserOnline(userId)
+
+		return {
+			userId,
+			online,
+			inGame: online && this.gameService.isUserInGame(userId),
+			activity: online
+				? this.gameService.getUserGameActivity(userId)
+				: 'offline',
+		};
 	}
 }

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-const MAX_PRESENCE_SOCKETS_PER_USER = 5;
+const MAX_PRESENCE_SOCKETS_PER_USER = 20;
 
 @Injectable()
 export class PresenceService {

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -91,6 +91,19 @@ export class PresenceService {
 		return [...sockets];
 	}
 
+	disconnectUserSockets(userId: number): void {
+		if (!this.server) {
+			return;
+		}
+
+		const socketIds = this.getUserSocketIds(userId);
+
+		for (const socketId of socketIds) {
+			const socket = this.server.sockets.sockets.get(socketId);
+			socket?.disconnect(true);
+		}
+	}
+
 	async emitFriendStatusChange(userId: number) {
 		const friendIds = await this.friendsService.getAcceptedFriendIds(userId);
 

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -54,4 +54,14 @@ export class PresenceService {
 	isUserOnline(userId: number): boolean {
 		return this.onlineUsers.has(userId);
 	}
+
+	getUserSocketIds(userId: number): string[] {
+		const sockets = this.onlineUsers.get(userId);
+
+		if (!sockets) {
+			return [];
+		}
+
+		return [...sockets];
+	}
 }

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -1,19 +1,32 @@
 import { Injectable } from '@nestjs/common';
 
+const MAX_PRESENCE_SOCKETS_PER_USER = 5;
+
 @Injectable()
 export class PresenceService {
 	private readonly onlineUsers = new Map<number, Set<string>>();
 	private readonly usersBySocket = new Map<string, number>();
 
-	connectUser(userId: number, socketId: string): boolean {
+	connectUser(userId: number, socketId: string): { connected: boolean; wasOffline: boolean } {
 		const sockets = this.onlineUsers.get(userId) ?? new Set<string>();
+
+		if (sockets.size >= MAX_PRESENCE_SOCKETS_PER_USER) {
+			return {
+				connected: false,
+				wasOffline: false,
+			};
+		}
+
 		const wasOffline = sockets.size === 0;
 
 		sockets.add(socketId);
 		this.onlineUsers.set(userId, sockets);
 		this.usersBySocket.set(socketId, userId);
 
-		return wasOffline;
+		return {
+			connected: true,
+			wasOffline,
+		};
 	}
 
 	disconnectSocket(socketId: string): { userId: number; isOffline: boolean } | null {

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -121,4 +121,18 @@ export class PresenceService {
 				: 'offline',
 		};
 	}
+
+	emitFriendsUpdated(userIds: number[]) {
+		if (!this.server) {
+			return;
+		}
+
+		for (const userId of userIds) {
+			const socketIds = this.getUserSocketIds(userId);
+
+			for (const socketId of socketIds) {
+				this.server.to(socketId).emit('friends_updated');
+			}
+		}
+	}
 }

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -123,15 +123,17 @@ export class PresenceService {
 	}
 
 	private buildFriendStatus(userId: number) {
-		const online = this.isUserOnline(userId)
+		const online = this.isUserOnline(userId);
+
+		const activity = online
+			? this.gameService.getUserGameActivity(userId)
+			: 'offline';
 
 		return {
 			userId,
 			online,
-			inGame: online && this.gameService.isUserInGame(userId),
-			activity: online
-				? this.gameService.getUserGameActivity(userId)
-				: 'offline',
+			inGame: activity === 'playing',
+			activity,
 		};
 	}
 

--- a/frontend/src/Store/presenceStore.ts
+++ b/frontend/src/Store/presenceStore.ts
@@ -9,6 +9,8 @@ interface PresenceState {
 	updateFriendStatus: (status: FriendStatus) => void;
 
 	clearFriendStatus: () => void;
+
+	mergeFriendStatus: (statuses: FriendStatus[]) => void;
 }
 
 export const usePresenceStore = create<PresenceState>((set) => ({
@@ -33,4 +35,14 @@ export const usePresenceStore = create<PresenceState>((set) => ({
 		set({
 			friendStatus: {},
 		}),
+
+	mergeFriendStatus: (statuses) =>
+	set((state) => ({
+		friendStatus: {
+			...state.friendStatus,
+			...Object.fromEntries(
+				statuses.map((status) => [status.userId, status]),
+			),
+		},
+	})),
 }));

--- a/frontend/src/Store/presenceStore.ts
+++ b/frontend/src/Store/presenceStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import type { FriendStatus } from "@/services/friendsService";
+
+interface PresenceState {
+	friendStatus: Record<number, FriendStatus>;
+
+	setFriendStatus: (statuses: FriendStatus[]) => void;
+
+	updateFriendStatus: (status: FriendStatus) => void;
+
+	clearFriendStatus: () => void;
+}
+
+export const usePresenceStore = create<PresenceState>((set) => ({
+	friendStatus: {},
+
+	setFriendStatus: (statuses) =>
+		set({
+			friendStatus: Object.fromEntries(
+				statuses.map((status) => [status.userId, status]),
+			),
+		}),
+
+	updateFriendStatus: (status) =>
+		set((state) => ({
+			friendStatus: {
+				...state.friendStatus,
+				[status.userId]: status,
+			},
+		})),
+
+	clearFriendStatus: () =>
+		set({
+			friendStatus: {},
+		}),
+}));

--- a/frontend/src/components/layout/Dashboard.tsx
+++ b/frontend/src/components/layout/Dashboard.tsx
@@ -11,6 +11,16 @@ import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { Chatbar } from "./Chatbar";
 import { Button } from "../ui/Button";
+import {
+	connectPresenceSocket,
+	disconnectPresenceSocket,
+} from "@/services/presenceSocket";
+
+import { friendsService } from "@/services/friendsService";
+
+import { usePresenceStore } from "@/Store/presenceStore";
+
+import type { FriendStatus } from "@/services/friendsService";
 
 export default function Dashboard() {
   const { t } = useTranslation();
@@ -23,6 +33,18 @@ export default function Dashboard() {
   const [isChat, setIsChat] = useState(false);
 
   const navigate = useNavigate();
+
+	const setFriendStatus = usePresenceStore(
+		(state) => state.setFriendStatus,
+	);
+
+	const updateFriendStatus = usePresenceStore(
+		(state) => state.updateFriendStatus,
+	);
+
+	const clearFriendStatus = usePresenceStore(
+		(state) => state.clearFriendStatus,
+	);
 
   const openLogin = () => setActiveModal("login");
   const closeModals = () => setActiveModal(null);
@@ -48,6 +70,57 @@ export default function Dashboard() {
     }
     getCurrentUser();
   }, []);
+
+	useEffect(() => {
+		if (!user) {
+			clearFriendStatus();
+			disconnectPresenceSocket();
+			return;
+		}
+
+		const socket = connectPresenceSocket();
+
+		async function loadFriendStatuses() {
+			try {
+				const statuses = await friendsService.getFriendsStatus();
+				setFriendStatus(statuses);
+			} catch (error) {
+				console.error("[PresenceSocket] failed to load statuses", error);
+			}
+		}
+
+		loadFriendStatuses();
+
+		socket.on("connect", () => {
+			console.log("[PresenceSocket] connected", socket.id);
+		});
+
+		socket.on("disconnect", () => {
+			console.log("[PresenceSocket] disconnected");
+		});
+
+		socket.on("friend_status_changed", (status: FriendStatus) => {
+			console.log("[PresenceSocket] friend status changed", status);
+
+			updateFriendStatus(status);
+		});
+
+		socket.on("connect_error", (error: Error) => {
+			console.error("[PresenceSocket] connection error:", error.message);
+		});
+
+		return () => {
+			socket.off("connect");
+			socket.off("disconnect");
+			socket.off("friend_status_changed");
+			socket.off("connect_error");
+		};
+	}, [
+		user,
+		setFriendStatus,
+		updateFriendStatus,
+		clearFriendStatus,
+	]);
 
   async function handleLogout() {
     try {
@@ -82,7 +155,7 @@ export default function Dashboard() {
   return (
     <div className="flex h-screen bg-linear-to-br from-slate-900 via-slate-800 to-black text-white">
 
-      <Sidebar 
+      <Sidebar
       user={user}
       onLoginClick={openLogin}
       onLogoutClick={handleLogout}

--- a/frontend/src/components/layout/Dashboard.tsx
+++ b/frontend/src/components/layout/Dashboard.tsx
@@ -97,6 +97,10 @@ export default function Dashboard() {
 			updateFriendStatus(status);
 		});
 
+		socket.on("friends_updated", () => {
+			window.dispatchEvent(new Event("friends_updated"));
+		});
+
 		socket.on("connect_error", (error: Error) => {
 			console.error("[PresenceSocket] connection error:", error.message);
 		});

--- a/frontend/src/components/layout/Dashboard.tsx
+++ b/frontend/src/components/layout/Dashboard.tsx
@@ -91,16 +91,8 @@ export default function Dashboard() {
 
 		loadFriendStatuses();
 
-		socket.on("connect", () => {
-			console.log("[PresenceSocket] connected", socket.id);
-		});
-
-		socket.on("disconnect", () => {
-			console.log("[PresenceSocket] disconnected");
-		});
 
 		socket.on("friend_status_changed", (status: FriendStatus) => {
-			console.log("[PresenceSocket] friend status changed", status);
 
 			updateFriendStatus(status);
 		});
@@ -110,8 +102,6 @@ export default function Dashboard() {
 		});
 
 		return () => {
-			socket.off("connect");
-			socket.off("disconnect");
 			socket.off("friend_status_changed");
 			socket.off("connect_error");
 		};
@@ -128,8 +118,8 @@ export default function Dashboard() {
 
       setUser(null);
 
-      const message = response.message 
-      ? t(`backend.${response.message}`) 
+      const message = response.message
+      ? t(`backend.${response.message}`)
       : t("auth.logoutSuccess");
       toast.success(message);
       navigate("/");

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -200,7 +200,14 @@
 			"load": "Failed to load friends data: {{error}}",
 			"search": "Failed to search users: {{error}}",
 			"action": "Action failed: {{error}}"
-		}
+		},
+		
+		"status": {
+			"online": "Online",
+			"offline": "Offline",
+			"available": "Available",
+			"inGame": "In game"
+			}
 	},
 
     "chat":{

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -201,7 +201,7 @@
 			"search": "Failed to search users: {{error}}",
 			"action": "Action failed: {{error}}"
 		},
-		
+
 		"status": {
 			"online": "Online",
 			"offline": "Offline",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -206,7 +206,8 @@
 			"online": "Online",
 			"offline": "Offline",
 			"available": "Available",
-			"inGame": "In game"
+			"inGame": "In game",
+			"waiting": "Waiting"
 			}
 	},
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -401,6 +401,7 @@
         "ERR_GAME_WAITING_PLAYERS": "Waiting for both players.",
         "ERR_GAME_SPECTATOR_MOVE": "Spectators cannot play.",
         "ERR_GAME_NOT_YOUR_TURN": "It is not your turn.",
+        "ERR_GAME_CANT_LEAVE_PLAYING": "Can't leave a game while playing",
         "ERR_MATCH_SELF_PLAY": "A player cannot play against themselves.",
         "ERR_MATCH_INVALID_WINNER": "The winner must be one of the two players.",
         "ERR_MATCH_SAVE_FAILED": "Unable to save match result.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -401,6 +401,7 @@
         "ERR_GAME_WAITING_PLAYERS": "Esperando a ambos jugadores.",
         "ERR_GAME_SPECTATOR_MOVE": "Los espectadores no pueden jugar.",
         "ERR_GAME_NOT_YOUR_TURN": "No es tu turno.",
+        "ERR_GAME_CANT_LEAVE_PLAYING": "No se puede salir de una partida en curso",
         "ERR_MATCH_SELF_PLAY": "Un jugador no puede jugar contra sí mismo.",
         "ERR_MATCH_INVALID_WINNER": "El ganador debe ser uno de los dos jugadores.",
         "ERR_MATCH_SAVE_FAILED": "No se pudo guardar el resultado del partido.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -206,7 +206,8 @@
 			"online": "En línea",
 			"offline": "Desconectado",
 			"available": "Disponible",
-			"inGame": "En partida"
+			"inGame": "En partida",
+			"waiting": "Esperando"
 			}
 	},
 

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -80,7 +80,7 @@
 			}
       	}
     },
-  
+
     "play": {
 		"myGames": {
 			"title": "Mis partidas",
@@ -200,7 +200,14 @@
 			"load": "Error al cargar los amigos: {{error}}",
 			"search": "Error al buscar usuarios: {{error}}",
 			"action": "La acción falló: {{error}}"
-		}
+		},
+
+		"status": {
+			"online": "En línea",
+			"offline": "Desconectado",
+			"available": "Disponible",
+			"inGame": "En partida"
+			}
 	},
 
     "chat":{

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -200,7 +200,14 @@
 			"load": "Erreur lors du chargement des amis : {{error}}",
 			"search": "Erreur lors de la recherche : {{error}}",
 			"action": "L'action a échoué : {{error}}"
-		}
+		},
+
+		"status": {
+			"online": "En ligne",
+			"offline": "Hors ligne",
+			"available": "Disponible",
+			"inGame": "En partie"
+			}
 	},
 
     "chat":{

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -402,6 +402,7 @@
         "ERR_GAME_WAITING_PLAYERS": "En attente des deux joueurs.",
         "ERR_GAME_SPECTATOR_MOVE": "Les spectateurs ne peuvent pas jouer.",
         "ERR_GAME_NOT_YOUR_TURN": "Ce n'est pas votre tour.",
+        "ERR_GAME_CANT_LEAVE_PLAYING": "Impossible de quitter une partie en cours",
         "ERR_MATCH_SELF_PLAY": "Un joueur ne peut pas jouer contre lui-même.",
         "ERR_MATCH_INVALID_WINNER": "Le vainqueur doit être l'un des deux participants.",
         "ERR_MATCH_SAVE_FAILED": "Impossible d'enregistrer le résultat du match.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -206,7 +206,8 @@
 			"online": "En ligne",
 			"offline": "Hors ligne",
 			"available": "Disponible",
-			"inGame": "En partie"
+			"inGame": "En partie",
+			"waiting": "En attente"
 			}
 	},
 

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -23,6 +23,7 @@ import {
 	type IncomingFriendRequest,
 	type OutgoingFriendRequest,
 	type PublicUser,
+	type FriendStatus,
 } from "@/services/friendsService";
 import {
 	connectPresenceSocket,
@@ -59,6 +60,7 @@ export default function Friends() {
 	const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [searchLoading, setSearchLoading] = useState(false);
+	const [friendStatus, setFriendStatus] = useState<Record<number, FriendStatus>>({});
 
 	const loadFriendsData = useCallback(async () => {
 		if (!user) return;
@@ -66,15 +68,21 @@ export default function Friends() {
 		try {
 			setLoading(true);
 
-			const [friendsData, incomingData, outgoingData] = await Promise.all([
+			const [friendsData, incomingData, outgoingData, statusData] = await Promise.all([
 				friendsService.getFriends(),
 				friendsService.getIncomingFriendRequests(),
 				friendsService.getOutgoingFriendRequests(),
+				friendsService.getFriendsStatus(),
 			]);
 
 			setFriends(friendsData);
 			setIncomingRequests(incomingData);
 			setOutgoingRequests(outgoingData);
+			setFriendStatus(
+				Object.fromEntries(
+					statusData.map((status) => [status.userId, status]),
+				),
+			);
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.load", { error: message }));
@@ -225,7 +233,6 @@ export default function Friends() {
 			</section>
 		);
 	}
-
 	return (
 		<section className="w-full max-w-5xl mx-auto px-6 py-10 text-white">
 			<div className="mb-8 text-center">
@@ -329,22 +336,38 @@ export default function Friends() {
 						<p className="text-white/50">{t("friends.list.empty")}</p>
 					) : (
 						<div className="space-y-3">
-							{friends.map((item) => (
-								<div
-									key={item.friendshipId}
-									className="flex items-center justify-between gap-4 bg-white/5 border border-white/10 rounded-xl p-3"
-								>
-									<UserRow user={item.friend} />
-									<Button
-										size="sm"
-										variant="danger"
-										onClick={() => handleRemoveFriend(item.friendshipId)}
+							{friends.map((item) => {
+								const status = friendStatus[item.friend.id];
+
+								return (
+									<div
+										key={item.friendshipId}
+										className="flex items-center justify-between gap-4 bg-white/5 border border-white/10 rounded-xl p-3"
 									>
-										<Trash2 size={16} />
-										{t("friends.actions.remove")}
-									</Button>
-								</div>
-							))}
+										<div>
+											<UserRow user={item.friend} />
+											<p className="text-xs text-white/40 mt-1">
+												{status?.online ? "Online" : "Offline"}
+												{status?.online && (
+													<>
+														{" · "}
+														{status.inGame ? "In game" : "Available"}
+													</>
+												)}
+											</p>
+										</div>
+
+										<Button
+											size="sm"
+											variant="danger"
+											onClick={() => handleRemoveFriend(item.friendshipId)}
+										>
+											<Trash2 size={16} />
+											{t("friends.actions.remove")}
+										</Button>
+									</div>
+								);
+							})}
 						</div>
 					)}
 				</Card>

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -24,6 +24,10 @@ import {
 	type OutgoingFriendRequest,
 	type PublicUser,
 } from "@/services/friendsService";
+import {
+	connectPresenceSocket,
+	disconnectPresenceSocket,
+} from "@/services/presenceSocket";
 
 interface CurrentUser {
 	id: number;
@@ -82,6 +86,32 @@ export default function Friends() {
 	useEffect(() => {
 		loadFriendsData();
 	}, [loadFriendsData]);
+	useEffect(() => {
+		if (!user) {
+			disconnectPresenceSocket();
+			return;
+		}
+
+		const socket = connectPresenceSocket();
+
+		socket.on("connect", () => {
+			console.log("[PresenceSocket] connected", socket.id);
+		});
+
+		socket.on("disconnect", () => {
+			console.log("[PresenceSocket] disconnected");
+		});
+
+		socket.on("connect_error", (error: Error) => {
+			console.error("[PresenceSocket] connection error:", error.message);
+		});
+
+		return () => {
+			socket.off("connect");
+			socket.off("disconnect");
+			socket.off("connect_error");
+		};
+	}, [user]);
 
 	async function handleSearch(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -315,11 +315,15 @@ export default function Friends() {
 										<div>
 											<UserRow user={item.friend} />
 											<p className="text-xs text-white/40 mt-1">
-												{status?.online ? "Online" : "Offline"}
+												{status?.online
+													? t("friends.status.online")
+													: t("friends.status.offline")}
 												{status?.online && (
 													<>
 														{" · "}
-														{status.inGame ? "In game" : "Available"}
+														{status.inGame
+															? t("friends.status.inGame")
+															: t("friends.status.available")}
 													</>
 												)}
 											</p>

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -329,13 +329,17 @@ export default function Friends() {
 										<div>
 											<UserRow user={item.friend} />
 											<p className="text-xs mt-1 flex items-center gap-2">
-												<StatusDot online={status?.online ?? false} />
+												<StatusDot activity={status?.activity ?? "offline"} />
 
 												<span
 													className={
-														status?.online
-															? "text-green-400"
-															: "text-red-400/80"
+														status?.activity === "offline"
+															? "text-red-400/80"
+															: status?.activity === "waiting"
+																? "text-yellow-300"
+																: status?.activity === "playing"
+																	? "text-cyan-300"
+																	: "text-green-400"
 													}
 												>
 													{status?.activity === "offline" && t("friends.status.offline")}
@@ -481,10 +485,29 @@ function UserRow({ user }: { user: PublicUser }) {
 	);
 }
 
-function StatusDot({ online }: { online: boolean }) {
-	if (!online) {
+function StatusDot({
+	activity,
+}: {
+	activity: FriendStatus["activity"];
+}) {
+	if (activity === "offline") {
 		return (
 			<span className="inline-flex size-2.5 rounded-full bg-red-400/70" />
+		);
+	}
+
+	if (activity === "waiting") {
+		return (
+			<span className="inline-flex size-2.5 rounded-full bg-yellow-400" />
+		);
+	}
+
+	if (activity === "playing") {
+		return (
+			<span className="relative flex size-2.5">
+				<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-cyan-400 opacity-75" />
+				<span className="relative inline-flex size-2.5 rounded-full bg-cyan-400" />
+			</span>
 		);
 	}
 

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -93,6 +93,19 @@ export default function Friends() {
 		loadFriendsData();
 	}, [loadFriendsData]);
 
+	useEffect(() => {
+		async function handleFriendsUpdated() {
+			await loadFriendsData();
+			await refreshFriendStatuses();
+		}
+
+		window.addEventListener("friends_updated", handleFriendsUpdated);
+
+		return () => {
+			window.removeEventListener("friends_updated", handleFriendsUpdated);
+		};
+	}, [loadFriendsData]);
+
 
 	async function handleSearch(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -25,10 +25,7 @@ import {
 	type PublicUser,
 	type FriendStatus,
 } from "@/services/friendsService";
-import {
-	connectPresenceSocket,
-	disconnectPresenceSocket,
-} from "@/services/presenceSocket";
+import { usePresenceStore } from "@/Store/presenceStore";
 
 interface CurrentUser {
 	id: number;
@@ -60,7 +57,9 @@ export default function Friends() {
 	const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [searchLoading, setSearchLoading] = useState(false);
-	const [friendStatus, setFriendStatus] = useState<Record<number, FriendStatus>>({});
+	const friendStatus = usePresenceStore(
+		(state) => state.friendStatus,
+	);
 
 	const loadFriendsData = useCallback(async () => {
 		if (!user) return;
@@ -68,21 +67,15 @@ export default function Friends() {
 		try {
 			setLoading(true);
 
-			const [friendsData, incomingData, outgoingData, statusData] = await Promise.all([
+			const [friendsData, incomingData, outgoingData] = await Promise.all([
 				friendsService.getFriends(),
 				friendsService.getIncomingFriendRequests(),
 				friendsService.getOutgoingFriendRequests(),
-				friendsService.getFriendsStatus(),
 			]);
 
 			setFriends(friendsData);
 			setIncomingRequests(incomingData);
 			setOutgoingRequests(outgoingData);
-			setFriendStatus(
-				Object.fromEntries(
-					statusData.map((status) => [status.userId, status]),
-				),
-			);
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.load", { error: message }));
@@ -94,42 +87,7 @@ export default function Friends() {
 	useEffect(() => {
 		loadFriendsData();
 	}, [loadFriendsData]);
-	useEffect(() => {
-		if (!user) {
-			disconnectPresenceSocket();
-			return;
-		}
 
-		const socket = connectPresenceSocket();
-
-		socket.on("connect", () => {
-			console.log("[PresenceSocket] connected", socket.id);
-		});
-
-		socket.on("disconnect", () => {
-			console.log("[PresenceSocket] disconnected");
-		});
-
-		socket.on("connect_error", (error: Error) => {
-			console.error("[PresenceSocket] connection error:", error.message);
-		});
-
-		socket.on("friend_status_changed", (status: FriendStatus) => {
-			console.log("[PresenceSocket] friend status changed", status);
-
-			setFriendStatus((previous) => ({
-				...previous,
-				[status.userId]: status,
-			}));
-		});
-
-		return () => {
-			socket.off("connect");
-			socket.off("disconnect");
-			socket.off("connect_error");
-			socket.off("friend_status_changed");
-		};
-	}, [user]);
 
 	async function handleSearch(event: React.FormEvent<HTMLFormElement>) {
 		event.preventDefault();

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -314,10 +314,16 @@ export default function Friends() {
 									>
 										<div>
 											<UserRow user={item.friend} />
-											<p className="text-xs text-white/40 mt-1 flex items-center gap-2">
+											<p className="text-xs mt-1 flex items-center gap-2">
 												<StatusDot online={status?.online ?? false} />
 
-												<span>
+												<span
+													className={
+														status?.online
+															? "text-green-400"
+															: "text-red-400/80"
+													}
+												>
 													{status?.online
 														? t("friends.status.online")
 														: t("friends.status.offline")}
@@ -451,7 +457,7 @@ function UserRow({ user }: { user: PublicUser }) {
 function StatusDot({ online }: { online: boolean }) {
 	if (!online) {
 		return (
-			<span className="inline-flex size-2.5 rounded-full bg-white/30" />
+			<span className="inline-flex size-2.5 rounded-full bg-red-400/70" />
 		);
 	}
 

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -84,6 +84,11 @@ export default function Friends() {
 		}
 	}, [user, t]);
 
+	const mergeFriendStatus = usePresenceStore(
+		(state) => state.mergeFriendStatus,
+	);
+
+
 	useEffect(() => {
 		loadFriendsData();
 	}, [loadFriendsData]);
@@ -139,6 +144,7 @@ export default function Friends() {
 			await friendsService.sendFriendRequest(userId);
 			toast.success(t("friends.success.requestSent"));
 			await loadFriendsData();
+			await refreshFriendStatuses();
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -150,6 +156,7 @@ export default function Friends() {
 			await friendsService.acceptFriendRequest(requestId);
 			toast.success(t("friends.success.accepted"));
 			await loadFriendsData();
+			await refreshFriendStatuses();
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -161,6 +168,7 @@ export default function Friends() {
 			await friendsService.declineFriendRequest(requestId);
 			toast.success(t("friends.success.declined"));
 			await loadFriendsData();
+			await refreshFriendStatuses();
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -172,10 +180,16 @@ export default function Friends() {
 			await friendsService.removeFriend(friendshipId);
 			toast.success(t("friends.success.removed"));
 			await loadFriendsData();
+			await refreshFriendStatuses();
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
 		}
+	}
+
+	async function refreshFriendStatuses() {
+		const statuses = await friendsService.getFriendsStatus();
+		mergeFriendStatus(statuses);
 	}
 
 	const incomingRequestBySenderId = useMemo(() => {

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -314,18 +314,23 @@ export default function Friends() {
 									>
 										<div>
 											<UserRow user={item.friend} />
-											<p className="text-xs text-white/40 mt-1">
-												{status?.online
-													? t("friends.status.online")
-													: t("friends.status.offline")}
-												{status?.online && (
-													<>
-														{" · "}
-														{status.inGame
-															? t("friends.status.inGame")
-															: t("friends.status.available")}
-													</>
-												)}
+											<p className="text-xs text-white/40 mt-1 flex items-center gap-2">
+												<StatusDot online={status?.online ?? false} />
+
+												<span>
+													{status?.online
+														? t("friends.status.online")
+														: t("friends.status.offline")}
+
+													{status?.online && (
+														<>
+															{" · "}
+															{status.inGame
+																? t("friends.status.inGame")
+																: t("friends.status.available")}
+														</>
+													)}
+												</span>
 											</p>
 										</div>
 
@@ -440,5 +445,20 @@ function UserRow({ user }: { user: PublicUser }) {
 				</p>
 			</div>
 		</div>
+	);
+}
+
+function StatusDot({ online }: { online: boolean }) {
+	if (!online) {
+		return (
+			<span className="inline-flex size-2.5 rounded-full bg-white/30" />
+		);
+	}
+
+	return (
+		<span className="relative flex size-2.5">
+			<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+			<span className="relative inline-flex size-2.5 rounded-full bg-green-400" />
+		</span>
 	);
 }

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -324,16 +324,29 @@ export default function Friends() {
 															: "text-red-400/80"
 													}
 												>
-													{status?.online
-														? t("friends.status.online")
-														: t("friends.status.offline")}
+													{status?.activity === "offline" && t("friends.status.offline")}
 
-													{status?.online && (
+													{status?.activity === "available" && (
 														<>
+															{t("friends.status.online")}
 															{" · "}
-															{status.inGame
-																? t("friends.status.inGame")
-																: t("friends.status.available")}
+															{t("friends.status.available")}
+														</>
+													)}
+
+													{status?.activity === "waiting" && (
+														<>
+															{t("friends.status.online")}
+															{" · "}
+															{t("friends.status.waiting")}
+														</>
+													)}
+
+													{status?.activity === "playing" && (
+														<>
+															{t("friends.status.online")}
+															{" · "}
+															{t("friends.status.inGame")}
 														</>
 													)}
 												</span>

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -114,10 +114,20 @@ export default function Friends() {
 			console.error("[PresenceSocket] connection error:", error.message);
 		});
 
+		socket.on("friend_status_changed", (status: FriendStatus) => {
+			console.log("[PresenceSocket] friend status changed", status);
+
+			setFriendStatus((previous) => ({
+				...previous,
+				[status.userId]: status,
+			}));
+		});
+
 		return () => {
 			socket.off("connect");
 			socket.off("disconnect");
 			socket.off("connect_error");
+			socket.off("friend_status_changed");
 		};
 	}, [user]);
 

--- a/frontend/src/services/friendsService.ts
+++ b/frontend/src/services/friendsService.ts
@@ -41,6 +41,17 @@ export interface FriendAcceptResponse {
 	updatedAt: string;
 }
 
+export interface FriendStatus {
+	userId: number;
+	online: boolean;
+	inGame: boolean;
+}
+
+async function getFriendsStatus(): Promise<FriendStatus[]> {
+	const response = await api.get("friends/status");
+	return response.data;
+}
+
 async function getFriends(): Promise<FriendListItem[]> {
 	const response = await api.get("friends");
 	return response.data;
@@ -97,9 +108,10 @@ export const friendsService = {
 	getFriends,
 	getIncomingFriendRequests,
 	getOutgoingFriendRequests,
-	searchUsers,
+	getFriendsStatus,
 	sendFriendRequest,
 	acceptFriendRequest,
 	declineFriendRequest,
 	removeFriend,
+	searchUsers,
 };

--- a/frontend/src/services/friendsService.ts
+++ b/frontend/src/services/friendsService.ts
@@ -41,10 +41,13 @@ export interface FriendAcceptResponse {
 	updatedAt: string;
 }
 
+export type FriendActivity = "offline" | "available" | "waiting" | "playing";
+
 export interface FriendStatus {
 	userId: number;
 	online: boolean;
 	inGame: boolean;
+	activity: FriendActivity;
 }
 
 async function getFriendsStatus(): Promise<FriendStatus[]> {

--- a/frontend/src/services/presenceSocket.ts
+++ b/frontend/src/services/presenceSocket.ts
@@ -1,0 +1,26 @@
+import { io, type Socket } from "socket.io-client";
+
+let presenceSocket: Socket | null = null;
+
+export function connectPresenceSocket(): Socket {
+	if (presenceSocket) {
+		return presenceSocket;
+	}
+
+	presenceSocket = io(window.location.origin, {
+		path: "/socket.io/",
+		transports: ["websocket"],
+		withCredentials: true,
+	});
+
+	return presenceSocket;
+}
+
+export function disconnectPresenceSocket(): void {
+	if (!presenceSocket) {
+		return;
+	}
+
+	presenceSocket.disconnect();
+	presenceSocket = null;
+}


### PR DESCRIPTION
# PR Description — Friends Online, Activity Status, and Realtime Social Updates

## Related issues


Closes #274 
Closes #294
Closes #295


---

## Goal

This PR adds a realtime presence and activity system for the Friends feature.

Users can now see accepted friends update live without refreshing the page.

The Friends page now shows whether each accepted friend is:

```txt
Offline
Online · Available
Online · Waiting
Online · In game
```

This PR also keeps the Friends page synchronized in realtime when friend requests are sent, accepted, declined, or removed.

The goal is to make the social part of the project feel alive and connected to the existing Socket.IO architecture.

---

## Summary

This PR adds:

- authenticated presence socket support
- in-memory online user tracking
- multiple-tab support
- friend-only status visibility
- protected friends status snapshot endpoint
- realtime friend status updates
- realtime game activity status updates
- realtime friend request/list synchronization
- global frontend presence store
- activity badges and translations
- logout cleanup for all active presence sockets
- This PR also introduces the first reusable global realtime infrastructure layer for future live frontend features.

---

## Main user-facing features

### Realtime friend presence

Accepted friends now update live between:

```txt
Offline
Online
```

without needing a manual refresh.

### Realtime activity status

Friends now show richer activity states derived directly from the backend game state:

```txt
Offline
Online · Available
Online · Waiting
Online · In game
```

The UI uses different colors for each state:

```txt
Offline  -> red
Available -> green
Waiting -> yellow
In game -> cyan
```

### Realtime friend request updates

The Friends page now updates live when users:

- send a friend request
- receive a friend request
- accept a friend request
- decline a friend request
- remove a friend

Both affected users receive the update.

### Initial status snapshot

A new protected endpoint was added:

```txt
GET /api/friends/status
```

It returns the current status of accepted friends only.

Example response:

```json
[
  {
    "userId": 12,
    "online": true,
    "inGame": false,
    "activity": "available"
  }
]
```

This snapshot is used when the app loads so the frontend starts with the correct current status before realtime updates arrive.

---

## Backend changes

### Presence module

Added a new presence feature area:

```txt
backend/src/presence/presence.module.ts
backend/src/presence/presence.gateway.ts
backend/src/presence/presence.service.ts
```

The presence module is responsible for:

- authenticating presence sockets
- tracking connected users in memory
- supporting multiple sockets/tabs per user
- cleaning up sockets on disconnect
- broadcasting friend status updates
- broadcasting friend list/request updates

### PresenceService

The service tracks active sockets using:

```ts
Map<number, Set<string>>
```

Meaning:

```txt
userId -> all active socket IDs for that user
```

This is important because one user may open the app in multiple tabs.

The service also tracks reverse socket ownership so disconnect cleanup is efficient:

```ts
Map<string, number>
```

Meaning:

```txt
socketId -> userId
```

### Presence socket limit

A per-user socket limit was added:

```txt
MAX_PRESENCE_SOCKETS_PER_USER = 20
```

This prevents one authenticated user from opening an excessive number of presence sockets and consuming backend memory/resources.

Extra authenticated presence sockets are rejected server-side.

### Authenticated socket identity

Presence sockets do not trust user IDs from the frontend.

Instead, the backend:

- reads the `access_token` cookie from the Socket.IO handshake
- verifies it using `JwtService`
- extracts the authenticated user ID from the verified JWT payload
- disconnects the socket if the token is missing or invalid

This keeps socket identity server-controlled.

### Friend-only visibility

Status updates are only emitted to accepted friends.

The backend never broadcasts global online users.

The `/friends/status` endpoint also only returns statuses for accepted friends of the authenticated user.

### Game activity integration

The presence system reads game activity from the existing game state instead of creating a second duplicated tracker.

Activity is derived from `GameService`:

```txt
available
waiting
playing
```

This avoids having a separate `inGameUsers` map that could go out of sync.
Presence updates are emitted whenever authoritative game state transitions occur (waiting, playing, finished, leave, timeout, reconnect forfeit).

### Logout cleanup

Logout now disconnects all active presence sockets for the user.

This fixes the multi-tab edge case where logging out in one tab could leave another tab’s socket alive and incorrectly keep the user online.

Flow:

```txt
logout
-> clear auth cookies
-> disconnect all presence sockets for that user
-> normal disconnect cleanup runs
-> friends receive offline update
```

---

## Frontend changes

### Global presence socket

Added a shared frontend presence socket service:

```txt
frontend/src/services/presenceSocket.ts
```

The app now opens one global presence socket while the user is authenticated.

This socket lives at the Dashboard level, not inside the Friends page.

That means the user stays online while using any authenticated page, for example:

- Home
- Play
- Live Games
- Game
- Profile
- Leaderboard
- History
- Friends

This also creates a reusable realtime base for future features such as:

- live Home/About stats
- live History refreshes
- notifications
- unread chat indicators
- live invite updates
- spectator/activity counters

### Global presence store

Added a Zustand presence store:

```txt
frontend/src/Store/presenceStore.ts
```

It stores friend statuses in a keyed object:

```ts
Record<number, FriendStatus>
```

This allows direct lookup by friend ID instead of repeatedly searching arrays during render.

### Friends page updates

Updated:

```txt
frontend/src/pages/Friends.tsx
```

The Friends page now:

- reads friend presence from the global store
- displays status dots and activity labels
- refreshes friend statuses after relevant actions
- reacts to realtime `friends_updated` events
- updates incoming/outgoing/friends lists without manual refresh

### Friends service

Updated:

```txt
frontend/src/services/friendsService.ts
```

Added status types and API call:

```ts
FriendActivity
FriendStatus
getFriendsStatus()
```

### Translations

Added EN/FR/ES labels for friend activity states.

Status labels include:

```txt
online
offline
available
waiting
inGame
```

---

## Modified file areas

### Backend

```txt
backend/src/app.module.ts
backend/src/auth/auth.controller.ts
backend/src/auth/auth.module.ts
backend/src/friends/friends.controller.ts
backend/src/friends/friends.service.ts
backend/src/friends/friends.module.ts
backend/src/modules/game/game.controller.ts
backend/src/modules/game/game.gateway.ts
backend/src/modules/game/game.module.ts
backend/src/modules/game/game.service.ts
backend/src/presence/presence.gateway.ts
backend/src/presence/presence.module.ts
backend/src/presence/presence.service.ts
```

### Frontend

```txt
frontend/src/components/layout/Dashboard.tsx
frontend/src/pages/Friends.tsx
frontend/src/services/friendsService.ts
frontend/src/services/presenceSocket.ts
frontend/src/Store/presenceStore.ts
frontend/src/i18n/en.json
frontend/src/i18n/fr.json
frontend/src/i18n/es.json
```

---

## Security notes

### Authentication

- Presence sockets are authenticated using the existing `access_token` cookie.
- The backend verifies the JWT before accepting the socket.
- The frontend never sends a user ID to claim online/activity status.
- Invalid or missing socket auth disconnects the socket.

### Authorization

- Users only receive status updates for accepted friends.
- `/friends/status` only returns statuses for accepted friends.
- Friend request updates are emitted only to affected users.
- No global user presence list is exposed.

### Privacy

Online and game activity status is treated as user activity data.

This PR avoids exposing that data through public user APIs such as `/users`.

### Resource protection

- Presence sockets are stored in memory.
- Multiple tabs are supported with `Set<string>`.
- Disconnect cleanup removes stale socket IDs.
- A per-user socket limit of 20 prevents unbounded socket growth.
- Extra sockets are disconnected server-side.

### Session/logout correctness

- Logging out disconnects all active presence sockets for that user.
- This prevents stale online states across multiple tabs.

---

## How to test

### Setup

Use at least 2 users, for example:

```txt
alice@example.com
bob@example.com
```

They should be accepted friends.

A third user is useful for privacy testing:

```txt
charlie@example.com
```

---

### 1. Test initial status snapshot

1. Log in as Alice.
2. Open:

```txt
http://localhost:1024/api/friends/status
```

Expected:

- only accepted friends are returned
- each status has:

```txt
userId
online
inGame
activity
```

Example:

```json
[
  {
    "userId": 2,
    "online": true,
    "inGame": false,
    "activity": "available"
  }
]
```

---

### 2. Test Online / Offline

1. Alice opens the Friends page.
2. Bob is logged out.

Expected:

```txt
Bob -> Offline
```

3. Bob logs in.

Expected on Alice without refresh:

```txt
Bob -> Online · Available
```

4. Bob closes/logs out.

Expected on Alice without refresh:

```txt
Bob -> Offline
```

---

### 3. Test multiple tabs

1. Bob opens the app in multiple tabs.
2. Alice should see Bob online.
3. Bob closes one tab.

Expected:

```txt
Bob stays Online
```

4. Bob closes/logs out from all tabs.

Expected:

```txt
Bob becomes Offline
```

---

### 4. Test socket limit

1. Open many tabs with the same user.
2. More than 20 presence sockets should not remain active for that user.

Expected:

- backend stays stable
- extra presence sockets are disconnected
- user remains online as long as at least one accepted socket remains connected

---

### 5. Test Waiting activity

1. Alice opens Friends page.
2. Bob creates a game / waiting room.

Expected on Alice without refresh:

```txt
Bob -> Online · Waiting
```

3. Bob cancels/leaves waiting room.

Expected:

```txt
Bob -> Online · Available
```

---

### 6. Test In game activity

1. Alice opens Friends page.
2. Bob starts or joins a game with another user.

Expected on Alice without refresh:

```txt
Bob -> Online · In game
```

3. Game finishes.

Expected on Alice without refresh:

```txt
Bob -> Online · Available
```

---

### 7. Test friend request realtime updates

Use 2 users in separate browsers.

#### Send request

1. Alice searches Bob and sends a friend request.

Expected:

- Alice outgoing request updates
- Bob incoming request appears without refresh

#### Accept request

1. Bob accepts Alice's request.

Expected:

- Bob incoming request disappears
- Bob friends list updates
- Alice outgoing request disappears
- Alice friends list updates
- friend status appears immediately with correct activity

#### Decline request

1. Send another request.
2. Receiver declines.

Expected:

- request disappears for both users without refresh

#### Remove friend

1. Alice removes Bob.

Expected:

- Bob disappears from Alice's friends list
- Alice disappears from Bob's friends list
- no refresh required

---

### 8. Test privacy / non-friends

1. Alice and Charlie are not friends.
2. Charlie logs in/out or enters a game.

Expected:

- Alice does not receive Charlie's status
- Charlie does not appear in Alice's Friends status list

---

### 9. Test logout multi-tab cleanup

1. Bob opens 2 tabs.
2. Alice sees Bob online.
3. Bob logs out from one tab.

Expected:

- all Bob presence sockets are disconnected
- Alice sees Bob offline without refresh
- Bob's other tab no longer keeps Bob online

---

## Known limitations / future work

This PR keeps the scope focused on accepted friends and current game activity.

Possible future improvements:

- Redis-backed presence for multi-instance backend deployments
- richer activity states such as spectating, replay negotiation, or replaying
- status privacy settings
- live notification center
- live Home/About stats using the global presence socket
- live History updates
- friend invite notifications
- more granular socket namespaces or event typing
- configurable presence socket limits through environment variables

---

## Notes

Presence is intentionally stored in memory, not in the database.

Online/activity status is temporary runtime state and should disappear when the backend restarts.

For a future multi-instance production deployment, this should be moved to shared infrastructure such as Redis.
