### PR TITLE
Feature/settings page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import Friends from "./pages/Friends";
 // import Chat from "./pages/Chat";
 import Rules from "./pages/Rules";
 import NotFound from "./pages/NotFound";
+import Settings from "./pages/Settings";
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
           <Route path="/game/:gameId" element={<Game />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/profile/:username" element={<Profile />} />
+          <Route path="/settings" element={<Settings />} />
           <Route path="/leaderboard" element={<LeaderBoard />} />
           <Route path="/friends" element={<Friends />} />
           <Route path="/history" element={<History />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { House, Gamepad2, UserRound, UsersRound, History, Trophy, Binoculars, BookOpenText } from "lucide-react";
+import { House, Gamepad2, UserRound, UsersRound, History, Trophy, Binoculars, BookOpenText, Settings as SettingsIcon } from "lucide-react";
 import LanguageSwitcher from "../ui/LanguageSwitcher";
 import { Button } from "@/components/ui/Button";
 
@@ -26,6 +26,7 @@ export function Sidebar({user, onLoginClick, onLogoutClick} : HeaderProps) {
     { to: "/play", label: "sidebar.game", icon: Gamepad2 },
     { to: "/spectate", label: "sidebar.spectate", icon: Binoculars },
     { to: "/profile", label: "sidebar.profile", icon: UserRound },
+    { to: "/settings", label: "sidebar.settings", icon: SettingsIcon },
     { to: "/leaderboard", label: "sidebar.leaderboard", icon: Trophy },
     { to: "/friends", label: "sidebar.friends", icon: UsersRound },
     { to: "/history", label: "sidebar.history", icon: History },
@@ -41,7 +42,7 @@ export function Sidebar({user, onLoginClick, onLogoutClick} : HeaderProps) {
 
 			<nav className="flex flex-col gap-2 mt-20">
 				{links.map(link => {
-				const Icon = link.icon 
+				const Icon = link.icon
 				return (
 					<NavLink
 					key={link.to}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -150,7 +150,10 @@
         },
         "security": {
             "title": "Security",
-            "description": "Manage two-factor authentication and future security options."
+            "description": "Manage two-factor authentication and future security options.",
+            "disableTitle": "Disable 2FA",
+            "disableDescription": "Disabling 2FA will be added later. For now, 2FA can only be enabled.",
+            "disableComingSoon": "Disable 2FA coming soon"
         }
     },
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -25,6 +25,7 @@
         "home": "Home",
         "game": "Play",
         "profile": "Profile",
+        "settings": "Settings",
         "leaderboard": "Leaderboard",
         "friends": "Friends",
         "chat": "Chat",
@@ -135,6 +136,21 @@
         "emptyBio": "Click edit profile to add a biography",
         "changeAvatar": "Change avatar",
         "avatarUpdated": "Avatar updated successfully"
+    },
+
+    "settings": {
+        "title": "Settings",
+        "description": "Manage your profile and account security.",
+        "notConnected": "Not connected",
+        "login": "Login to manage your settings",
+        "profile": {
+            "title": "Profile information",
+            "description": "Update your username, biography, and avatar."
+        },
+        "security": {
+            "title": "Security",
+            "description": "Manage two-factor authentication and future security options."
+        }
     },
 
     "leaderboard":{

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -120,10 +120,6 @@
             "winrateValue": "{{value}}%"
         },
         "bio": "Bio",
-        "buttons": {
-            "edit": "Edit profile",
-            "save": "Save changes"
-        },
         "about": {
             "title": "About",
             "notConnected": "Not connected",
@@ -136,7 +132,8 @@
         "emptyBio": "Click edit profile to add a biography",
         "changeAvatar": "Change avatar",
         "avatarUpdated": "Avatar updated successfully",
-        "username": "Username"
+        "username": "Username",
+        "editProfile": "Edit profile"
     },
 
     "settings": {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -135,7 +135,8 @@
         "xp": "{{current}} / {{max}} XP",
         "emptyBio": "Click edit profile to add a biography",
         "changeAvatar": "Change avatar",
-        "avatarUpdated": "Avatar updated successfully"
+        "avatarUpdated": "Avatar updated successfully",
+        "username": "Username"
     },
 
     "settings": {
@@ -145,7 +146,10 @@
         "login": "Login to manage your settings",
         "profile": {
             "title": "Profile information",
-            "description": "Update your username, biography, and avatar."
+            "description": "Update your username, biography, and avatar.",
+            "updated": "Profile updated successfully",
+            "saving": "Saving...",
+            "save": "Save changes"
         },
         "security": {
             "title": "Security",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -147,7 +147,10 @@
 		},
 		"security": {
 			"title": "Seguridad",
-			"description": "Gestiona la autenticación de dos factores y futuras opciones de seguridad."
+			"description": "Gestiona la autenticación de dos factores y futuras opciones de seguridad.",
+			"disableTitle": "Desactivar 2FA",
+			"disableDescription": "La desactivación de 2FA se añadirá más adelante. Por ahora, la 2FA solo se puede activar.",
+			"disableComingSoon": "Desactivar 2FA próximamente"
 		}
 	},
 

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -119,10 +119,6 @@
 			"winrateValue": "{{value}}%"
 		},
 		"bio": "Biografía",
-		"buttons": {
-			"edit": "Editar perfil",
-			"save": "Guardar cambios"
-      	},
 		"about": {
 			"title": "Acerca de",
 			"notConnected": "No conectado",
@@ -136,7 +132,8 @@
 		"uploading": "Subiendo...",
   		"changeAvatar": "Cambiar avatar",
   		"avatarUpdated": "Avatar actualizado correctamente",
-		"username": "Nombre de Usuario"
+		"username": "Nombre de Usuario",
+		"editProfile": "Editar perfil"
 	},
 
 	"settings": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -25,6 +25,7 @@
 		"home": "Inicio",
 		"game": "Jugar",
 		"profile": "Perfil",
+        "settings": "Ajustes",
 		"leaderboard": "Clasificación",
 		"friends": "Amigos",
 		"chat": "Chat",
@@ -135,6 +136,21 @@
 		"uploading": "Subiendo...",
   		"changeAvatar": "Cambiar avatar",
   		"avatarUpdated": "Avatar actualizado correctamente"
+	},
+
+	"settings": {
+		"title": "Ajustes",
+		"description": "Gestiona tu perfil y la seguridad de tu cuenta.",
+		"notConnected": "No conectado",
+		"login": "Inicia sesión para gestionar tus ajustes",
+		"profile": {
+			"title": "Información del perfil",
+			"description": "Actualiza tu nombre de usuario, biografía y avatar."
+		},
+		"security": {
+			"title": "Seguridad",
+			"description": "Gestiona la autenticación de dos factores y futuras opciones de seguridad."
+		}
 	},
 
     "leaderboard": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -135,7 +135,8 @@
 		"emptyBio": "Haz clic en editar perfil para añadir una biografía",
 		"uploading": "Subiendo...",
   		"changeAvatar": "Cambiar avatar",
-  		"avatarUpdated": "Avatar actualizado correctamente"
+  		"avatarUpdated": "Avatar actualizado correctamente",
+		"username": "Nombre de Usuario"
 	},
 
 	"settings": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -147,7 +147,10 @@
         },
         "security": {
             "title": "Sécurité",
-            "description": "Gère l'authentification à deux facteurs et les futures options de sécurité."
+            "description": "Gère l'authentification à deux facteurs et les futures options de sécurité.",
+            "disableTitle": "Désactiver la 2FA",
+            "disableDescription": "La désactivation de la 2FA sera ajoutée plus tard. Pour l’instant, la 2FA peut seulement être activée.",
+            "disableComingSoon": "Désactivation de la 2FA bientôt disponible"
         }
     },
 

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -135,7 +135,8 @@
         "emptyBio": "Cliquez sur modifier profil pour ajouter une biographie",
         "uploading": "Téléchargement...",
         "changeAvatar": "Changer l'avatar",
-        "avatarUpdated": "Avatar mis à jour avec succès"
+        "avatarUpdated": "Avatar mis à jour avec succès",
+		"username": " Nom d'utilisateur"
     },
 
     "settings": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -119,10 +119,6 @@
             "winrateValue": "{{value}}%"
         },
         "bio": "Bio",
-        "buttons": {
-            "edit": "Modifier le profil",
-            "save": "Sauvegarder les changements"
-        },
         "about": {
             "title": "À propos",
             "notConnected": "Non connecté",
@@ -136,7 +132,8 @@
         "uploading": "Téléchargement...",
         "changeAvatar": "Changer l'avatar",
         "avatarUpdated": "Avatar mis à jour avec succès",
-		"username": " Nom d'utilisateur"
+        "username": " Nom d'utilisateur",
+        "editProfile": "Modifier le profil"
     },
 
     "settings": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -25,6 +25,7 @@
         "home": "Accueil",
         "game": "Jouer",
         "profile": "Profil",
+        "settings": "Paramètres",
         "leaderboard": "Classement",
         "friends": "Amis",
         "chat": "Discussion",
@@ -135,6 +136,21 @@
         "uploading": "Téléchargement...",
         "changeAvatar": "Changer l'avatar",
         "avatarUpdated": "Avatar mis à jour avec succès"
+    },
+
+    "settings": {
+        "title": "Paramètres",
+        "description": "Gère ton profil et la sécurité de ton compte.",
+        "notConnected": "Non connecté",
+        "login": "Connecte-toi pour gérer tes paramètres",
+        "profile": {
+            "title": "Informations du profil",
+            "description": "Modifie ton nom d'utilisateur, ta biographie et ton avatar."
+        },
+        "security": {
+            "title": "Sécurité",
+            "description": "Gère l'authentification à deux facteurs et les futures options de sécurité."
+        }
     },
 
     "leaderboard": {

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -158,6 +158,7 @@ export default function Friends() {
 			toast.success(t("friends.success.requestSent"));
 			await loadFriendsData();
 			await refreshFriendStatuses();
+			window.dispatchEvent(new Event("friends_updated"));
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -170,6 +171,7 @@ export default function Friends() {
 			toast.success(t("friends.success.accepted"));
 			await loadFriendsData();
 			await refreshFriendStatuses();
+			window.dispatchEvent(new Event("friends_updated"));
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -182,6 +184,7 @@ export default function Friends() {
 			toast.success(t("friends.success.declined"));
 			await loadFriendsData();
 			await refreshFriendStatuses();
+			window.dispatchEvent(new Event("friends_updated"));
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));
@@ -194,6 +197,7 @@ export default function Friends() {
 			toast.success(t("friends.success.removed"));
 			await loadFriendsData();
 			await refreshFriendStatuses();
+			window.dispatchEvent(new Event("friends_updated"));
 		} catch (error: any) {
 			const message = error.response?.data?.message || error.message;
 			toast.error(t("friends.errors.action", { error: message }));

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -89,8 +89,20 @@ export default function Friends() {
 	);
 
 
+	async function refreshFriendStatuses() {
+		if (!user) return;
+
+		const statuses = await friendsService.getFriendsStatus();
+		mergeFriendStatus(statuses);
+	}
+
 	useEffect(() => {
-		loadFriendsData();
+		async function loadPageData() {
+			await loadFriendsData();
+			await refreshFriendStatuses();
+		}
+
+		loadPageData();
 	}, [loadFriendsData]);
 
 	useEffect(() => {
@@ -204,10 +216,7 @@ export default function Friends() {
 		}
 	}
 
-	async function refreshFriendStatuses() {
-		const statuses = await friendsService.getFriendsStatus();
-		mergeFriendStatus(statuses);
-	}
+
 
 	const incomingRequestBySenderId = useMemo(() => {
 		return new Map(

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -332,7 +332,12 @@ export default function Friends() {
 					) : (
 						<div className="space-y-3">
 							{friends.map((item) => {
-								const status = friendStatus[item.friend.id];
+								const status = friendStatus[item.friend.id] ?? {
+									userId: item.friend.id,
+									online: false,
+									inGame: false,
+									activity: "offline" as const,
+								};
 
 								return (
 									<div
@@ -342,22 +347,22 @@ export default function Friends() {
 										<div>
 											<UserRow user={item.friend} />
 											<p className="text-xs mt-1 flex items-center gap-2">
-												<StatusDot activity={status?.activity ?? "offline"} />
+												<StatusDot activity={status.activity ?? "offline"} />
 
 												<span
 													className={
-														status?.activity === "offline"
+														status.activity === "offline"
 															? "text-red-400/80"
-															: status?.activity === "waiting"
+															: status.activity === "waiting"
 																? "text-yellow-300"
-																: status?.activity === "playing"
+																: status.activity === "playing"
 																	? "text-cyan-300"
 																	: "text-green-400"
 													}
 												>
-													{status?.activity === "offline" && t("friends.status.offline")}
+													{status.activity === "offline" && t("friends.status.offline")}
 
-													{status?.activity === "available" && (
+													{status.activity === "available" && (
 														<>
 															{t("friends.status.online")}
 															{" · "}
@@ -365,7 +370,7 @@ export default function Friends() {
 														</>
 													)}
 
-													{status?.activity === "waiting" && (
+													{status.activity === "waiting" && (
 														<>
 															{t("friends.status.online")}
 															{" · "}
@@ -373,7 +378,7 @@ export default function Friends() {
 														</>
 													)}
 
-													{status?.activity === "playing" && (
+													{status.activity === "playing" && (
 														<>
 															{t("friends.status.online")}
 															{" · "}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from "react";
 import { userService } from "../services/userService";
 import { useTranslation } from "react-i18next";
-import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
 import { useOutletContext } from "react-router";
 import { toast } from "sonner";
@@ -41,7 +40,7 @@ type RelationshipState = "SELF" | "FRIEND" | "PENDING_SENT" | "PENDING_RECEIVED"
 
 export default function Profile() {
   const { t } = useTranslation();
-  const [user, setUser] =
+  const [user] =
     useOutletContext<
       [User | null, React.Dispatch<React.SetStateAction<User | null>>]
     >();
@@ -59,9 +58,6 @@ export default function Profile() {
   const [unlockedAchievements, setUnlockedAchievements] = useState<string[]>([])
   const [allAchievements, setAllAchievements] = useState<Achievement[]>([]);
 
-  const [twoFactorCode, setTwoFactorCode] = useState("");
-  const [qrCodeDataUrl, setQrCodeDataUrl] = useState("");
-  const [isTwoFactorLoading, setIsTwoFactorLoading] = useState(false);
   const navigate = useNavigate()
 
 
@@ -220,51 +216,6 @@ export default function Profile() {
         />
       </section>
     );
-  }
-
-
-
-  async function handleEnableTwoFactor() {
-    if (!user) return;
-
-    try {
-      setIsTwoFactorLoading(true);
-      const result = await userService.enableTwoFactor();
-      setQrCodeDataUrl(result.qrCodeDataUrl);
-      toast.success(t("auth.twofa.setupStarted"));
-    } catch (error: any) {
-      const serverMessage = error.response?.data?.message || error.message;
-      const finalMessage = Array.isArray(serverMessage)
-        ? serverMessage[0]
-        : serverMessage;
-      toast.error(t("auth.error") + finalMessage);
-    } finally {
-      setIsTwoFactorLoading(false);
-    }
-  }
-
-  async function handleVerifyTwoFactor() {
-    if (!user) return;
-
-    try {
-      setIsTwoFactorLoading(true);
-      const result = await userService.verifyTwoFactorSetup(twoFactorCode);
-      toast.success(result.message);
-
-      const refreshedUser = await userService.getMe();
-      setUser(refreshedUser);
-
-      setTwoFactorCode("");
-      setQrCodeDataUrl("");
-    } catch (error: any) {
-      const serverMessage = error.response?.data?.message || error.message;
-      const finalMessage = Array.isArray(serverMessage)
-        ? serverMessage[0]
-        : serverMessage;
-      toast.error(t("auth.error") + finalMessage);
-    } finally {
-      setIsTwoFactorLoading(false);
-    }
   }
 
   const state = getRelationshipState()
@@ -429,73 +380,6 @@ export default function Profile() {
 			</Button>
 		)}
 
-        {/* 2FA */}
-        {isMe && ( <div className="mt-8">
-          <p className="text-white/50 text-sm mb-2">{t("auth.twofa.title")}</p>
-
-          {profileData?.isTwoFactorEnabled ? (
-            <div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
-              <p className="text-sm text-green-400 font-medium">
-                {t("auth.twofa.enabled")}
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <Button
-                type="button"
-                onClick={handleEnableTwoFactor}
-                disabled={isTwoFactorLoading}
-                className="w-full"
-              >
-                {isTwoFactorLoading
-                  ? t("auth.twofa.loading")
-                  : t("auth.twofa.enable")}
-              </Button>
-
-              {qrCodeDataUrl && (
-                <div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10 space-y-4">
-                  <img
-                    src={qrCodeDataUrl}
-                    alt="2FA QR code"
-                    className="mx-auto rounded-lg bg-white p-2"
-                  />
-
-                  <Input
-                    value={twoFactorCode}
-                    onChange={(e) => setTwoFactorCode(e.target.value)}
-                    placeholder={t("auth.twofa.enterCode")}
-                    maxLength={6}
-                  />
-
-                  <Button
-                    type="button"
-                    onClick={handleVerifyTwoFactor}
-                    disabled={isTwoFactorLoading || twoFactorCode.length !== 6}
-                    className="w-full"
-                  >
-                    {isTwoFactorLoading
-                      ? t("auth.twofa.verifying")
-                      : t("auth.twofa.verify")}
-                  </Button>
-
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={handleEnableTwoFactor}
-                    disabled={isTwoFactorLoading}
-                    className="w-full"
-                  >
-                    {t("auth.twofa.regenerate")}
-                  </Button>
-                </div>
-
-              )}
-
-            </div>
-
-          )}
-        </div>
-        )}
       </div>
     </section>
   );

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -199,6 +199,18 @@ export default function Profile() {
       setLoading(false);
 
   }, [profileData?.id, isMe, user]);
+  
+  useEffect(() => {
+	async function handleFriendsUpdated() {
+		await loadFriendshipData();
+	}
+
+	window.addEventListener("friends_updated", handleFriendsUpdated);
+
+	return () => {
+		window.removeEventListener("friends_updated", handleFriendsUpdated);
+	};
+}, []);
 
   if (!user || loading) {
     return (

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -53,10 +53,7 @@ export default function Profile() {
   const [friends, setFriends] = useState<FriendListItem[]>([])
   const [incomingRequests, setIncomingRequests] = useState<IncomingFriendRequest[]>([])
   const [outgoingRequests, setOutgoingRequests] = useState<OutgoingFriendRequest[]>([])
-  
-  const [isEdit, isInEdit] = useState(false);
-  const [userName, setUserName] = useState(user?.username || "");
-  const [bio, setBio] = useState(user?.bio || "");
+
   const [loading, setLoading] = useState(true);
 
   const [unlockedAchievements, setUnlockedAchievements] = useState<string[]>([])
@@ -70,7 +67,7 @@ export default function Profile() {
 	const [isAvatarUploading, setIsAvatarUploading] = useState(false);
 	const avatarInputRef = useRef<HTMLInputElement | null>(null);
 
- 
+
   useEffect(() => {
     async function loadProfile() {
       if (isMe) {
@@ -83,7 +80,7 @@ export default function Profile() {
           const data = await userService.getUserByUsername(username)
           setProfileData(data)
           setLoading(false)
-        } 
+        }
         catch (error) {
           navigate("/dashboard");
         }
@@ -111,7 +108,7 @@ export default function Profile() {
 
   async function loadFriendshipData() {
     try {
-          
+
       const [friends, incomingRequests, outgoingRequests] = await Promise.all([
       friendsService.getFriends(),
       friendsService.getIncomingFriendRequests(),
@@ -133,7 +130,7 @@ export default function Profile() {
       await friendsService.sendFriendRequest(profileData.id)
       toast.success(t("friends.success.requestSent"))
       await loadFriendshipData()
-    } 
+    }
     catch (error: any) {
 
       const message = error.response?.data?.message || error.message
@@ -179,10 +176,6 @@ export default function Profile() {
   useEffect(() => {
     if (!profileData) return;
 
-    if (isMe && user) {
-      setUserName(user.username);
-      setBio(user.bio);
-    }
 
       async function fetchAllAchievments() {
         try {
@@ -207,7 +200,7 @@ export default function Profile() {
       fetchAchievements()
 
       setLoading(false);
-    
+
   }, [profileData?.id, isMe, user]);
 
   if (!user || loading) {
@@ -231,23 +224,7 @@ export default function Profile() {
     );
   }
 
-  async function handleSave() {
-    if (!user) return;
-    if (isEdit) {
-      try {
-        await userService.updateUser(user.id, { username: userName, bio: bio });
-        setUser({ ...user, username: userName, bio: bio });
-        toast.info(t("auth.buttons.edit"));
-      } catch (error: any) {
-        const serverMessage = error.response?.data?.message || error.message;
-        const finalMessage = Array.isArray(serverMessage)
-          ? serverMessage[0]
-          : serverMessage;
-        toast.error(t("auth.error") + finalMessage);
-      }
-    }
-    isInEdit(!isEdit);
-  }
+
 
   async function handleEnableTwoFactor() {
     if (!user) return;
@@ -324,7 +301,7 @@ export default function Profile() {
   return (
     <section className="w-full max-w-3xl mx-auto px-6 py-10">
       <div className="relative bg-slate-900 border border-white/10 rounded-2xl shadow-2xl p-8 overflow-hidden">
-        
+
         <CardTitle className="absolute top-6 left-6 bg-linear-to-r from-cyan-400 to-pink-500 bg-clip-text text-transparent">
           {t("sidebar.profile")}
         </CardTitle>
@@ -345,7 +322,7 @@ export default function Profile() {
             />
             <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-md opacity-0 group-hover:opacity-100 transition"></div>
             </div>
-			{isMe && isEdit && (
+			{isMe &&  (
 				<div className="mt-3 flex justify-center">
 					<input
 						ref={avatarInputRef}
@@ -371,17 +348,13 @@ export default function Profile() {
 			)}
 
           {/* USERNAME */}
-          {isEdit ? (
-            <Input
-              value={userName}
-              onChange={(e) => setUserName(e.target.value)}
-              className="text-center"
-            />
-          ) : (
-            <h1 className="text-2xl font-bold tracking-wide">
-              <Username name={profileData?.username ?? ""} variant="profile" />
-            </h1>
-          )}
+          <h1 className="text-2xl font-bold tracking-wide">
+			<Username
+				name={profileData?.username ?? ""}
+				variant="profile"
+			/>
+		</h1>
+
         </div>
 
         <div>
@@ -481,29 +454,31 @@ export default function Profile() {
             {t("profile.bio")}
           </p>
 
-          <div className="w-full min-h-20 bg-white/5 border border-white/10 rounded-xl px-4 py-3 transition focus-within:border-cyan-400">
-            {isEdit ? (
-            <textarea
-              value={bio}
-              onChange={(e) => setBio(e.target.value)}
-              className="w-full bg-transparent focus:outline-none resize-none text-sm text-white/80"
-            />
-          ) : profileData?.bio ? (
-                <p className="text-sm leading-relaxed text-white/80">
-                  {profileData?.bio}
-                </p>
-          ) : (
-            <p className="text-sm text-white/30 italic">
-                {t("profile.emptyBio")}
-            </p>
-          )}
-            </div>          
+
+		<div className="w-full min-h-20 bg-white/5 border border-white/10 rounded-xl px-4 py-3 transition focus-within:border-cyan-400">
+			{profileData?.bio ? (
+				<p className="text-sm leading-relaxed text-white/80">
+					{profileData?.bio}
+				</p>
+			) : (
+				<p className="text-sm text-white/30 italic">
+					{t("profile.emptyBio")}
+				</p>
+			)}
+		</div>
+
+
         </div>
 
         {/* BUTTON */}
-        {isMe && ( <Button onClick={handleSave} className="mt-8 w-full flex justify-center">
-          {isEdit ? t("profile.buttons.save") : t("profile.buttons.edit")}
-        </Button> )}
+        {isMe && (
+			<Button
+				onClick={() => navigate("/settings")}
+				className="mt-8 w-full flex justify-center"
+			>
+				{t("settings.title")}
+			</Button>
+		)}
 
         {/* 2FA */}
         {isMe && ( <div className="mt-8">
@@ -563,12 +538,12 @@ export default function Profile() {
                   >
                     {t("auth.twofa.regenerate")}
                   </Button>
-                </div> 
-                
+                </div>
+
               )}
-              
+
             </div>
-            
+
           )}
         </div>
         )}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 // import avatarImg from "/avatar.png"
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import { userService } from "../services/userService";
 import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/Input";
@@ -64,8 +64,6 @@ export default function Profile() {
   const [isTwoFactorLoading, setIsTwoFactorLoading] = useState(false);
   const navigate = useNavigate()
 
-	const [isAvatarUploading, setIsAvatarUploading] = useState(false);
-	const avatarInputRef = useRef<HTMLInputElement | null>(null);
 
 
   useEffect(() => {
@@ -269,33 +267,6 @@ export default function Profile() {
     }
   }
 
-	async function handleAvatarUpload(event: React.ChangeEvent<HTMLInputElement>) {
-		if (!user) return;
-
-		const file = event.target.files?.[0];
-
-		if (!file) return;
-
-		try {
-			setIsAvatarUploading(true);
-
-			const updatedUser = await userService.uploadAvatar(file);
-			setUser({ ...user, avatar: updatedUser.avatar });
-
-			toast.success(t("profile.avatarUpdated"));
-		} catch (error: any) {
-			const serverMessage = error.response?.data?.message || error.message;
-			const finalMessage = Array.isArray(serverMessage)
-				? serverMessage[0]
-				: serverMessage;
-
-			toast.error(t("auth.error") + finalMessage);
-		} finally {
-			setIsAvatarUploading(false);
-			event.target.value = "";
-		}
-	}
-
   const state = getRelationshipState()
 
   return (
@@ -322,30 +293,8 @@ export default function Profile() {
             />
             <div className="absolute inset-0 rounded-full bg-cyan-500/30 blur-md opacity-0 group-hover:opacity-100 transition"></div>
             </div>
-			{isMe &&  (
-				<div className="mt-3 flex justify-center">
-					<input
-						ref={avatarInputRef}
-						type="file"
-						accept="image/png,image/jpeg,image/webp"
-						onChange={handleAvatarUpload}
-						disabled={isAvatarUploading}
-						className="hidden"
-					/>
 
-					<Button
-						type="button"
-						variant="secondary"
-						onClick={() => avatarInputRef.current?.click()}
-						disabled={isAvatarUploading}
-						className="px-4 py-2 text-xs"
-					>
-						{isAvatarUploading
-            ? t("profile.uploading")
-            : t("profile.changeAvatar")}
-					</Button>
-				</div>
-			)}
+
 
           {/* USERNAME */}
           <h1 className="text-2xl font-bold tracking-wide">

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -124,6 +124,7 @@ export default function Profile() {
       await friendsService.sendFriendRequest(profileData.id)
       toast.success(t("friends.success.requestSent"))
       await loadFriendshipData()
+	  window.dispatchEvent(new Event("friends_updated"));
     }
     catch (error: any) {
 
@@ -143,6 +144,7 @@ export default function Profile() {
       await friendsService.acceptFriendRequest(request.requestId)
       toast.success(t("friends.success.accepted"))
       await loadFriendshipData()
+	  window.dispatchEvent(new Event("friends_updated"));
     }
     catch (error: any) {
       const message = error.response?.data?.message || error.message;
@@ -160,6 +162,7 @@ export default function Profile() {
       await friendsService.removeFriend(friendship.friendshipId)
       toast.success(t("friends.success.removed"));
       await loadFriendshipData()
+	  window.dispatchEvent(new Event("friends_updated"));
     }
     catch (error: any) {
       const message = error.response?.data?.message || error.message;

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -376,7 +376,7 @@ export default function Profile() {
 				onClick={() => navigate("/settings")}
 				className="mt-8 w-full flex justify-center"
 			>
-				{t("settings.title")}
+				{t("profile.editProfile")}
 			</Button>
 		)}
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -279,10 +279,31 @@ export default function Settings() {
 						</p>
 
 						{user.isTwoFactorEnabled ? (
-							<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
-								<p className="text-sm text-green-400 font-medium">
-									{t("auth.twofa.enabled")}
-								</p>
+							<div className="space-y-4">
+								<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
+									<p className="text-sm text-green-400 font-medium">
+										{t("auth.twofa.enabled")}
+									</p>
+								</div>
+
+								<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
+									<p className="text-sm font-semibold text-white">
+										{t("settings.security.disableTitle")}
+									</p>
+
+									<p className="text-sm text-white/50 mt-2">
+										{t("settings.security.disableDescription")}
+									</p>
+
+									<Button
+										type="button"
+										variant="secondary"
+										disabled
+										className="mt-4 w-full"
+									>
+										{t("settings.security.disableComingSoon")}
+									</Button>
+								</div>
 							</div>
 						) : (
 							<div className="space-y-4">

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -188,7 +188,7 @@ export default function Settings() {
 				</p>
 			</div>
 
-			<div className="grid gap-6">
+			<div className="grid gap-8">
 				<Card className="space-y-6">
 					<div>
 						<CardTitle>{t("settings.profile.title")}</CardTitle>
@@ -261,7 +261,6 @@ export default function Settings() {
 						</Button>
 					</div>
 				</Card>
-
 
 				<Card className="space-y-6">
 					<div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from "react-i18next";
+import { useNavigate, useOutletContext } from "react-router-dom";
+import { Button } from "@/components/ui/Button";
+import { Card, CardDescription, CardTitle } from "@/components/ui/Card";
+import { EmptyStateCard } from "@/components/ui/EmptyCard";
+
+interface User {
+	id: number;
+	username: string;
+	wins: number;
+	losses: number;
+	draws: number;
+	bio: string;
+	avatar: string;
+	xp: number;
+	isTwoFactorEnabled: boolean;
+}
+
+export default function Settings() {
+	const { t } = useTranslation();
+	const navigate = useNavigate();
+
+	const [user] =
+		useOutletContext<
+			[User | null, React.Dispatch<React.SetStateAction<User | null>>]
+		>();
+
+	if (!user) {
+		return (
+			<section className="w-full max-w-3xl mx-auto px-6 py-10 text-white">
+				<EmptyStateCard
+					title={t("settings.title")}
+					icon={<span className="text-xl font-bold">?</span>}
+					message={t("settings.notConnected")}
+					description={t("settings.login")}
+					actions={
+						<Button onClick={() => navigate("/")}>
+							{t("buttons.backHome")}
+						</Button>
+					}
+				/>
+			</section>
+		);
+	}
+
+	return (
+		<section className="w-full max-w-4xl mx-auto px-6 py-10 text-white">
+			<div className="mb-8">
+				<h1 className="text-3xl font-bold bg-linear-to-r from-cyan-400 to-pink-500 bg-clip-text text-transparent">
+					{t("settings.title")}
+				</h1>
+				<p className="text-white/50 mt-2">
+					{t("settings.description")}
+				</p>
+			</div>
+
+			<div className="grid gap-6">
+				<Card>
+					<CardTitle>{t("settings.profile.title")}</CardTitle>
+					<CardDescription className="text-white/50">
+						{t("settings.profile.description")}
+					</CardDescription>
+				</Card>
+
+				<Card>
+					<CardTitle>{t("settings.security.title")}</CardTitle>
+					<CardDescription className="text-white/50">
+						{t("settings.security.description")}
+					</CardDescription>
+				</Card>
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,12 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useNavigate, useOutletContext } from "react-router-dom";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card, CardDescription, CardTitle } from "@/components/ui/Card";
 import { EmptyStateCard } from "@/components/ui/EmptyCard";
 import { Input } from "@/components/ui/Input";
 import { toast } from "sonner";
 import { userService } from "@/services/userService";
+import { Avatar } from "@/components/ui/Avatar";
 
 interface User {
 	id: number;
@@ -32,6 +33,8 @@ export default function Settings() {
 	const [username, setUsername] = useState(user?.username || "");
 	const [bio, setBio] = useState(user?.bio || "");
 	const [isSaving, setIsSaving] = useState(false);
+	const [isAvatarUploading, setIsAvatarUploading] = useState(false);
+	const avatarInputRef = useRef<HTMLInputElement | null>(null);
 
 	useEffect(() => {
 		if (!user) return;
@@ -56,6 +59,35 @@ export default function Settings() {
 				/>
 			</section>
 		);
+	}
+
+	async function handleAvatarUpload(event: React.ChangeEvent<HTMLInputElement>) {
+		if (!user) return;
+
+		const file = event.target.files?.[0];
+
+		if (!file) return;
+
+		try {
+			setIsAvatarUploading(true);
+
+			const updatedUser = await userService.uploadAvatar(file);
+			setUser(updatedUser);
+
+			toast.success(t("profile.avatarUpdated"));
+		} catch (error: any) {
+			const serverMessage =
+				error.response?.data?.message || error.message;
+
+			const finalMessage = Array.isArray(serverMessage)
+				? serverMessage[0]
+				: serverMessage;
+
+			toast.error(t("auth.error") + finalMessage);
+		} finally {
+			setIsAvatarUploading(false);
+			event.target.value = "";
+		}
 	}
 
 	async function handleSaveProfile() {
@@ -108,6 +140,34 @@ export default function Settings() {
 					</div>
 
 					<div className="space-y-4">
+						<div className="flex flex-col items-center gap-4">
+							<Avatar
+								src={user.avatar}
+								alt={user.username}
+								size="lg"
+								className="border border-white/20"
+							/>
+
+							<input
+								ref={avatarInputRef}
+								type="file"
+								accept="image/png,image/jpeg,image/webp"
+								onChange={handleAvatarUpload}
+								disabled={isAvatarUploading}
+								className="hidden"
+							/>
+
+							<Button
+								type="button"
+								variant="secondary"
+								onClick={() => avatarInputRef.current?.click()}
+								disabled={isAvatarUploading}
+							>
+								{isAvatarUploading
+									? t("profile.uploading")
+									: t("profile.changeAvatar")}
+							</Button>
+						</div>
 						<div>
 							<p className="text-sm text-white/50 mb-2">
 								{t("profile.username")}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,8 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { useNavigate, useOutletContext } from "react-router-dom";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card, CardDescription, CardTitle } from "@/components/ui/Card";
 import { EmptyStateCard } from "@/components/ui/EmptyCard";
+import { Input } from "@/components/ui/Input";
+import { toast } from "sonner";
+import { userService } from "@/services/userService";
 
 interface User {
 	id: number;
@@ -20,10 +24,21 @@ export default function Settings() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
 
-	const [user] =
+	const [user, setUser] =
 		useOutletContext<
 			[User | null, React.Dispatch<React.SetStateAction<User | null>>]
 		>();
+
+	const [username, setUsername] = useState(user?.username || "");
+	const [bio, setBio] = useState(user?.bio || "");
+	const [isSaving, setIsSaving] = useState(false);
+
+	useEffect(() => {
+		if (!user) return;
+
+		setUsername(user.username);
+		setBio(user.bio);
+	}, [user]);
 
 	if (!user) {
 		return (
@@ -43,6 +58,34 @@ export default function Settings() {
 		);
 	}
 
+	async function handleSaveProfile() {
+		if (!user) return;
+
+		try {
+			setIsSaving(true);
+
+			const updatedUser = await userService.updateUser(user.id, {
+				username,
+				bio,
+			});
+
+			setUser(updatedUser);
+
+			toast.success(t("settings.profile.updated"));
+		} catch (error: any) {
+			const serverMessage =
+				error.response?.data?.message || error.message;
+
+			const finalMessage = Array.isArray(serverMessage)
+				? serverMessage[0]
+				: serverMessage;
+
+			toast.error(t("auth.error") + finalMessage);
+		} finally {
+			setIsSaving(false);
+		}
+	}
+
 	return (
 		<section className="w-full max-w-4xl mx-auto px-6 py-10 text-white">
 			<div className="mb-8">
@@ -55,11 +98,49 @@ export default function Settings() {
 			</div>
 
 			<div className="grid gap-6">
-				<Card>
-					<CardTitle>{t("settings.profile.title")}</CardTitle>
-					<CardDescription className="text-white/50">
-						{t("settings.profile.description")}
-					</CardDescription>
+				<Card className="space-y-6">
+					<div>
+						<CardTitle>{t("settings.profile.title")}</CardTitle>
+
+						<CardDescription className="text-white/50 mt-2">
+							{t("settings.profile.description")}
+						</CardDescription>
+					</div>
+
+					<div className="space-y-4">
+						<div>
+							<p className="text-sm text-white/50 mb-2">
+								{t("profile.username")}
+							</p>
+
+							<Input
+								value={username}
+								onChange={(e) => setUsername(e.target.value)}
+							/>
+						</div>
+
+						<div>
+							<p className="text-sm text-white/50 mb-2">
+								{t("profile.bio")}
+							</p>
+
+							<textarea
+								value={bio}
+								onChange={(e) => setBio(e.target.value)}
+								className="w-full min-h-28 bg-white/5 border border-white/10 rounded-xl px-4 py-3 resize-none text-sm text-white/80 focus:outline-none focus:border-cyan-400"
+							/>
+						</div>
+
+						<Button
+							onClick={handleSaveProfile}
+							disabled={isSaving}
+							className="w-full"
+						>
+							{isSaving
+								? t("settings.profile.saving")
+								: t("settings.profile.save")}
+						</Button>
+					</div>
 				</Card>
 
 				<Card>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -35,6 +35,9 @@ export default function Settings() {
 	const [isSaving, setIsSaving] = useState(false);
 	const [isAvatarUploading, setIsAvatarUploading] = useState(false);
 	const avatarInputRef = useRef<HTMLInputElement | null>(null);
+	const [twoFactorCode, setTwoFactorCode] = useState("");
+	const [qrCodeDataUrl, setQrCodeDataUrl] = useState("");
+	const [isTwoFactorLoading, setIsTwoFactorLoading] = useState(false);
 
 	useEffect(() => {
 		if (!user) return;
@@ -87,6 +90,62 @@ export default function Settings() {
 		} finally {
 			setIsAvatarUploading(false);
 			event.target.value = "";
+		}
+	}
+
+	async function handleEnableTwoFactor() {
+		if (!user) return;
+
+		try {
+			setIsTwoFactorLoading(true);
+
+			const result = await userService.enableTwoFactor();
+
+			setQrCodeDataUrl(result.qrCodeDataUrl);
+
+			toast.success(t("auth.twofa.setupStarted"));
+		} catch (error: any) {
+			const serverMessage =
+				error.response?.data?.message || error.message;
+
+			const finalMessage = Array.isArray(serverMessage)
+				? serverMessage[0]
+				: serverMessage;
+
+			toast.error(t("auth.error") + finalMessage);
+		} finally {
+			setIsTwoFactorLoading(false);
+		}
+	}
+
+	async function handleVerifyTwoFactor() {
+		if (!user) return;
+
+		try {
+			setIsTwoFactorLoading(true);
+
+			const result =
+				await userService.verifyTwoFactorSetup(twoFactorCode);
+
+			toast.success(result.message);
+
+			const refreshedUser = await userService.getMe();
+
+			setUser(refreshedUser);
+
+			setTwoFactorCode("");
+			setQrCodeDataUrl("");
+		} catch (error: any) {
+			const serverMessage =
+				error.response?.data?.message || error.message;
+
+			const finalMessage = Array.isArray(serverMessage)
+				? serverMessage[0]
+				: serverMessage;
+
+			toast.error(t("auth.error") + finalMessage);
+		} finally {
+			setIsTwoFactorLoading(false);
 		}
 	}
 
@@ -203,12 +262,90 @@ export default function Settings() {
 					</div>
 				</Card>
 
-				<Card>
-					<CardTitle>{t("settings.security.title")}</CardTitle>
-					<CardDescription className="text-white/50">
-						{t("settings.security.description")}
-					</CardDescription>
+
+				<Card className="space-y-6">
+					<div>
+						<CardTitle>
+							{t("settings.security.title")}
+						</CardTitle>
+
+						<CardDescription className="text-white/50 mt-2">
+							{t("settings.security.description")}
+						</CardDescription>
+					</div>
+
+					<div>
+						<p className="text-white/50 text-sm mb-2">
+							{t("auth.twofa.title")}
+						</p>
+
+						{user.isTwoFactorEnabled ? (
+							<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10">
+								<p className="text-sm text-green-400 font-medium">
+									{t("auth.twofa.enabled")}
+								</p>
+							</div>
+						) : (
+							<div className="space-y-4">
+								<Button
+									type="button"
+									onClick={handleEnableTwoFactor}
+									disabled={isTwoFactorLoading}
+									className="w-full"
+								>
+									{isTwoFactorLoading
+										? t("auth.twofa.loading")
+										: t("auth.twofa.enable")}
+								</Button>
+
+								{qrCodeDataUrl && (
+									<div className="bg-white/5 rounded-lg py-4 px-4 border border-white/10 space-y-4">
+										<img
+											src={qrCodeDataUrl}
+											alt="2FA QR code"
+											className="mx-auto rounded-lg bg-white p-2"
+										/>
+
+										<Input
+											value={twoFactorCode}
+											onChange={(e) =>
+												setTwoFactorCode(e.target.value)
+											}
+											placeholder={t("auth.twofa.enterCode")}
+											maxLength={6}
+										/>
+
+										<Button
+											type="button"
+											onClick={handleVerifyTwoFactor}
+											disabled={
+												isTwoFactorLoading ||
+												twoFactorCode.length !== 6
+											}
+											className="w-full"
+										>
+											{isTwoFactorLoading
+												? t("auth.twofa.verifying")
+												: t("auth.twofa.verify")}
+										</Button>
+
+										<Button
+											type="button"
+											variant="secondary"
+											onClick={handleEnableTwoFactor}
+											disabled={isTwoFactorLoading}
+											className="w-full"
+										>
+											{t("auth.twofa.regenerate")}
+										</Button>
+									</div>
+								)}
+							</div>
+						)}
+					</div>
 				</Card>
+
+
 			</div>
 		</section>
 	);


### PR DESCRIPTION
Closes #298

## Summary

This PR introduces a dedicated `/settings` page and moves private account-management functionality out of the public Profile page.

The goal is to properly separate:

```txt
public/social profile display
```

from:

```txt
private account/security management
```

The Profile page is now mostly display-oriented, while Settings owns profile mutations and security actions.

This PR also fixes several frontend relationship/presence refresh inconsistencies introduced during the `/profile/:username` work from PR #299.

---

# Main changes

## New `/settings` page

Created:

```txt
frontend/src/pages/Settings.tsx
```

Added:

* `/settings` route
* sidebar navigation entry
* EN/FR/ES i18n keys
* authenticated empty-state handling

The page follows the current application UI style and structure.

---

# Profile editing moved to Settings

Moved from `Profile.tsx` to `Settings.tsx`:

* username editing
* bio editing
* avatar upload
* 2FA enable/setup/verify flow

Settings now owns account mutations while Profile focuses on displaying public user information.

---

# Profile page cleanup

`Profile.tsx` is now mostly public/display-focused.

The page now mainly contains:

* avatar
* username
* stats
* achievements
* level/winrate
* bio
* friendship actions
* settings button for the current user

This aligns better with the new `/profile/:username` architecture introduced in PR #299.

---

# 2FA improvements

Moved 2FA management into Settings:

* enable 2FA
* QR setup flow
* verification flow

Added a future-ready UI placeholder for:

```txt
Disable 2FA
```

without implementing the backend logic yet.

This keeps the Settings page extensible for future account/security work.

---

# Friendship/presence refresh fixes

This PR also fixes several frontend synchronization issues noticed during PR #299 review/testing.

Previously:

* `/profile/me` sometimes required manual refresh after friendship actions
* relationship buttons could become stale between `/profile` and `/friends`
* newly accepted friends could temporarily appear offline until refresh
* presence dots and labels could become inconsistent

Fixes added:

* shared frontend `friends_updated` synchronization events
* friendship data reload after add/accept/remove actions
* friend status refresh after relationship updates
* safer fallback handling for missing presence state

This improves consistency between:

* `/profile`
* `/profile/:username`
* `/friends`

without introducing new backend socket events yet.

---

# Security considerations

This PR does not change backend authorization rules.

Important protections remain backend-owned:

```ts
if (req.user.sub !== id) {
	throw new ForbiddenException('ERR_USER_UPDATE_FORBIDDEN');
}
```

2FA setup continues to rely on the authenticated JWT user identity rather than frontend-provided user IDs.

Public Profile pages continue exposing only safe public user fields.

---

# How to test

## Settings route

While authenticated:

```txt
/settings
```

Expected:

* Settings page loads
* current user data appears

While unauthenticated:

```txt
/settings
```

Expected:

* 401 backend response
* frontend displays login/empty state

---

# Username/bio update

From Settings:

* change username
* change bio
* save

Expected:

* success toast
* current user context updates immediately
* Profile page updates immediately
* Sidebar/topbar updates immediately

---

# Avatar upload

From Settings:

* upload PNG/JPEG/WebP avatar

Expected:

* avatar updates immediately
* Profile reflects new avatar
* Sidebar/topbar reflect new avatar

---

# 2FA flow

From Settings:

* enable 2FA
* scan QR code
* verify 6-digit code

Expected:

* user becomes 2FA-enabled
* QR flow disappears after verification
* enabled state appears

---

# Friendship synchronization

Test using 2 users.

Expected:

* add/remove/accept actions update correctly between `/profile` and `/friends`
* relationship buttons stay synchronized
* newly accepted friends receive correct presence state without refresh
* presence labels and status dots stay consistent

---

# What's next

Future account-management work will likely include:

* disable 2FA
* change email
* change password
* privacy/account preferences

Future realtime improvements may replace temporary browser event synchronization with dedicated socket events for:

* friendship updates
* profile updates
* public user refreshes
* presence synchronization

