### PR TITLE
[BACKEND] - Update seed XP values to match game logic

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -111,7 +111,7 @@ async function main() {
     const losses = total - wins - draws;
 
     // ── XP & Update User ──────────────────────
-    const xp = wins * 20 + draws * 10 + losses * 5;
+    const xp = wins * 100 + draws * 50 + losses * 25;
     await prisma.user.update({ where: { id: user.id }, data: { wins, losses, draws, xp, totalGames: total } });
   }
   console.log('\x1b[32m✓ Updated Users\' XP and Stats\x1b[0m');


### PR DESCRIPTION
Closes #315 

## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

### **BACKEND:**

- `prisma/seed.ts`: updated XP constants to match `matches.service.ts` (win: 20→100, draw: 10→50, loss: 5→25)

## Why

PR #302 reworked the XP gain logic in `matches.service.ts` but the seed values were not updated. Seeded dummy users had XP totals inconsistent with what the live game awards.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

### Dev Test 1 — Seeded XP matches live values

**1. Rebuild dev stack:**

```bash
make downv
make re
```

**2. Log in as any dummy user and check their profile XP and rank.**

**3. Check the leaderboard reflects correct XP ordering.**

---

### Prod Test 1 — Seeded XP matches live values

**1. Rebuild prod stack:**

```bash
make p-downv
make prod
```

**2. Log in as any dummy user and check their profile XP and rank.**

**3. Check the leaderboard reflects correct XP ordering.**
