### PR TITLE
[INFRA] - Make `nuke` idempotent

### DIFF
--- a/make/clean.mk
+++ b/make/clean.mk
@@ -37,7 +37,7 @@ nuke: ## Full wipe — stops stack, removes volumes + images, deletes .env + sec
 		*) \
 			exit 0 ;; \
 	esac
-	
+
 _nuke-apply: # Runs a full wipe
   	# ── Prompt for Postgres Image Removal ────────────────────────────────────
 	@printf "$(CYAN)Remove postgres:$(POSTGRES_VERSION)? Skip if rebuilding soon$(RES) [y/N] "; read ans; \
@@ -51,8 +51,9 @@ _nuke-apply: # Runs a full wipe
   	# ── Stop Stack, Remove Containers + Volumes ──────────────────────────────
 	@echo ""
 	@echo "$(CYAN)<Stopping stack and removing containers + volumes>$(RES)"
-	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) $(ENV_DEV) down --volumes --remove-orphans
-	@docker compose -p prod -f $(COMPOSE_FILE) -f $(COMPOSE_PROD) $(ENV_PROD) down --volumes --remove-orphans
+	@[ -f .env.dev ] && [ -f .env.prod ] || echo "$(ORANGE)Warning: .env files not found — compose context unavailable. Compose down skipped; Docker pruning will still run.$(RES)"
+	@docker compose -p dev -f $(COMPOSE_FILE) -f $(COMPOSE_DEV) $(ENV_DEV) down --volumes --remove-orphans 2>/dev/null || true
+	@docker compose -p prod -f $(COMPOSE_FILE) -f $(COMPOSE_PROD) $(ENV_PROD) down --volumes --remove-orphans 2>/dev/null || true
 	@docker volume prune -f
 
   	# ── Remove dev & prod Images ─────────────────────────────────────────────
@@ -73,5 +74,5 @@ _nuke-apply: # Runs a full wipe
 	@echo "   Run \`make up\` to rebuild from scratch."
 	@echo ""
 	@docker system df
-	
+
 .PHONY: clean nuke _nuke-apply


### PR DESCRIPTION
As requested by @simo1616, delivered with extra love 😂

## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

### **INFRA:**

- `make/clean.mk`: added `2>/dev/null || true` to both `docker compose down` commands in `_nuke-apply`, and a warning message when `.env` files are not found

## Why

`make nuke` deletes `.env.dev` and `.env.prod` at the end of its run. A second `nuke`
would then fail immediately — `docker compose` requires those files via `--env-file`
and exits with an error if they are missing, which Make treats as a build failure and halts.

`2>/dev/null` suppresses the error message from `docker compose`. `|| true` replaces
the non-zero exit code with success — Make stops execution on any non-zero exit, so
this is the idiomatic one-liner for "try this, but do not stop if it fails." The
volume, image, and cache pruning that follows does not need the env files and now
always runs regardless.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

### Test 1 — nuke is idempotent

**1. Run nuke once to wipe everything:**

```bash
make nuke
```

**2. Run nuke a second time and confirm it completes without errors:**

```bash
make nuke
```

> Expected: warning message about missing `.env` files, followed by Docker pruning output. No Make error.

---