### PR TITLE
[BUG] - Fix 401 console errors on page load and logout

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -167,6 +167,24 @@ export class AuthController {
 		return this.authService.me(req.user.sub);
 	}
 
+	@Public()
+	@Get('session')
+	async session(@Req() req: Request) {
+		const token = req.cookies?.['access_token'];
+
+		if (!token) {
+			return { authenticated: false, user: null };
+		}
+
+		try {
+			const payload = await this.jwtService.verifyAsync<JwtPayload>(token);
+			const user = await this.authService.me(payload.sub);
+			return { authenticated: true, user };
+		} catch {
+			return { authenticated: false, user: null };
+		}
+	}
+
 	@ApiOperation({ summary: 'Generate 2FA setup data for the authenticated user' })
 	@ApiResponse({
 		status: 201,

--- a/frontend/src/components/layout/Dashboard.tsx
+++ b/frontend/src/components/layout/Dashboard.tsx
@@ -84,13 +84,10 @@ export default function Dashboard() {
   useEffect(() => {
     async function getCurrentUser() {
       try {
-        const result = await userService.getMe();
-        setUser(result);
+        const result = await userService.getSession();
+        setUser(result.authenticated ? result.user : null);
       } catch (error: unknown) {
-			if (
-				error instanceof AxiosError &&
-				error.response?.status !== 401
-			) {
+			if (error instanceof AxiosError) {
 				const finalMessage = getBackendErrorMessage(error);
 
 				toast.error(

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -175,7 +175,7 @@ export default function Profile() {
   }
 
   useEffect(() => {
-    if (!profileData) return;
+    if (!profileData || !user) return;
 
 
       async function fetchAllAchievments() {
@@ -204,7 +204,7 @@ export default function Profile() {
         try {
           const rankData = await userService.getUserRank(profileData!.id)
           setRank(rankData.rank)
-        } 
+        }
         catch (error) {
           console.error("Failed to fetch user rank: ", error)
         }
@@ -392,7 +392,7 @@ export default function Profile() {
 				</p>
 			) : (
         <p></p>
-        
+
       )}
 		</div>
 

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -11,6 +11,7 @@ export const userService = {
 	disableTwoFactor,
 	updatePassword,
 	updateEmail,
+	getSession,
     getMe,
     userLogout,
     getUserHistory,
@@ -20,6 +21,11 @@ export const userService = {
   getAllAchievements,
   getUserByUsername,
   getUserRank,
+}
+
+export interface SessionResponse {
+	authenticated: boolean;
+	user: unknown | null;
 }
 
 export interface LoginResponse {
@@ -64,6 +70,11 @@ export interface UpdateEmailResponse {
 export async function userLogout() {
   const response = await api.post("auth/logout");
   return response.data;
+}
+
+export async function getSession(): Promise<SessionResponse> {
+	const response = await api.get("auth/session");
+	return response.data;
 }
 
 export async function getMe() {

--- a/frontend/src/services/userService.ts
+++ b/frontend/src/services/userService.ts
@@ -1,4 +1,5 @@
 import { api } from "@/services/api";
+import type { User } from "@/type/user.types";
 
 export const userService = {
     getUser,
@@ -25,7 +26,7 @@ export const userService = {
 
 export interface SessionResponse {
 	authenticated: boolean;
-	user: unknown | null;
+	user: User | null;
 }
 
 export interface LoginResponse {


### PR DESCRIPTION
## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

### **Backend:**

- Added a new public `GET /auth/session` endpoint in `auth.controller.ts`
- Marked with `@Public()` so the JWT guard skips it entirely. It can never return 401
- Reads the `access_token` cookie manually, verifies it, and fetches the user
- Returns `{ authenticated: true, user }` when a valid session exists
- Returns `{ authenticated: false, user: null }` when no cookie is present or the token is invalid/expired

### **Frontend:**

- Added `SessionResponse` interface and `getSession()` function in `userService.ts`
- Imported the `User` type into `userService.ts` to properly type the `user` field in `SessionResponse`
- Updated `Dashboard.tsx` to call `getSession()` on page load instead of `getMe()`
- Auth state is now set from `result.authenticated` instead of catching a thrown 401 exception
- Added `!user` guard to the `useEffect` early return in `Profile.tsx` to prevent achievement and rank requests from firing during logout

## Why

### 401 when logged out

When the app loads and no user is logged in, the frontend called `GET /auth/me` to check session status. Since that endpoint does not have the `@Public()` tag, it was intercepted by JWT guard and returned a 401. 

Even though the frontend handled the error silently, browsers (Firefox and Chromium) always log failed HTTP requests to the console — this cannot be suppressed from JavaScript.

This PR introduces a dedicated `GET /auth/session` endpoint that always returns 200. It reports whether a session is active instead of refusing unauthenticated requests outright. 

This keeps `/auth/me` protected and unchanged, and removes the console noise without weakening any security guarantees. The JWT is still fully validated inside `/auth/session`.

### Multiple 401s when logging out from the user's own profile page

A second source of 401s was found on the profile page. 

When logging out, `user` becoming `null` triggered a re-render that caused `Profile.tsx` to re-run its data-fetching effect. `profileData` still held its old value at that moment, so the guard that was meant to stop early requests did not catch it. 

Adding `!user` to that guard prevents the achievement and rank requests from firing when the session is already gone.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

## Production Tests

### Test 1 — no console error on page load while logged out

**1. Open the app in a browser while not logged in.**

**2. Open DevTools (F12) and go to the Console tab.**

**3. Confirm no 401 error appears.**

---

### Test 2 — login still works correctly

**1. Log in with a valid account.**

**2. Confirm the user is recognized and the dashboard loads normally.**

---

### Test 3 — session persists on hard refresh

**1. While logged in, hard refresh the page (Ctrl+Shift+R).**

**2. Confirm the user is still recognized after reload.**

> No login prompt should appear if the cookie is still valid.

---

### Test 4 — logout works correctly

**1. Log out.**

**2. Confirm the user is cleared and the login page is shown.**

**3. Check the Console tab — no errors should appear.**

---

### Test 5 — no 401 errors when logging out from the profile page

**1. Log in and navigate to your own profile page.**

**2. Open DevTools (F12) and go to the Console tab.**

**3. Log out.**

**4. Confirm no 401 errors appear for `/api/users/allAchievements`, `/api/users/:id/achievements`, or `/api/users/:id/rank`.**

---

## Development Tests

### Dev Test 1 — same tests as prod

Repeat Prod Tests 1 through 5 against the dev stack.
