### PR TITLE
[REFACTOR] - Clean game/chat code and improve responsive board

### DIFF
--- a/backend/src/modules/chat/chat.gateway.ts
+++ b/backend/src/modules/chat/chat.gateway.ts
@@ -7,6 +7,7 @@ import {
 	WebSocketServer,
 } from '@nestjs/websockets';
 import { Namespace } from 'socket.io';
+import { randomUUID } from 'crypto';
 import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
 import type { AuthSocket } from 'src/auth/jwt-auth.guard';
 import { SendChatMessageDto } from './dto/chat.dto';
@@ -31,13 +32,19 @@ const allowedOrigins = trimmedOrigins.filter(function (origin) {
 	},
 })
 @UseGuards(JwtAuthGuard)
-@UsePipes(new ValidationPipe({ whitelist: true }))
+@UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
 export class ChatGateway {
 	@WebSocketServer()
 	server!: Namespace;
 
 	constructor(private readonly usersService: UsersService) {}
 
+	/**
+	 * Builds the public chat payload from the authenticated socket user and broadcasts it.
+	 *
+	 * @param body - Validated chat message received from the socket.
+	 * @param client - Authenticated socket that sent the message.
+	 */
 	@SubscribeMessage('chat_send')
 	async handleChatSend(
 		@MessageBody() body: SendChatMessageDto,
@@ -45,7 +52,7 @@ export class ChatGateway {
 	) {
 		const user = await this.usersService.getUser(client.data.user.sub);
 		const message = {
-			id: Date.now(),
+			id: randomUUID(),
 			content: body.content,
 			createdAt: new Date().toISOString(),
 			user: {

--- a/backend/src/modules/chat/dto/chat.dto.ts
+++ b/backend/src/modules/chat/dto/chat.dto.ts
@@ -1,8 +1,14 @@
-import { IsString, MaxLength, MinLength } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
+/**
+ * Payload received from the chat socket when a user sends a message.
+ * The content is trimmed before validation and broadcast.
+ */
 export class SendChatMessageDto {
-  @IsString({ message: 'ERR_CHAT_MSG_STRING' })
-  @MinLength(1, { message: 'ERR_CHAT_MSG_EMPTY' })
-  @MaxLength(500, { message: 'ERR_CHAT_MSG_TOO_LONG' })
-  content!: string;
+	@Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+	@IsString({ message: 'ERR_CHAT_MSG_STRING' })
+	@IsNotEmpty({ message: 'ERR_CHAT_MSG_EMPTY' })
+	@MaxLength(500, { message: 'ERR_CHAT_MSG_TOO_LONG' })
+	content!: string;
 }

--- a/backend/src/modules/game/game.controller.ts
+++ b/backend/src/modules/game/game.controller.ts
@@ -1,88 +1,94 @@
-import { Controller, Get, Param, Post, Req } from '@nestjs/common';
+import { Controller, Get, Param, Post, Req, Res } from '@nestjs/common';
+import type { Response } from 'express';
 import { GameService } from './game.service';
 import type { AuthRequest } from 'src/auth/jwt-auth.guard';
 import { UsersService } from 'src/users/users.service';
 import {
-  	ApiTags,
-  	ApiOperation,
-  	ApiParam,
-  	ApiResponse,
-  	ApiCookieAuth,
+	ApiTags,
+	ApiOperation,
+	ApiParam,
+	ApiResponse,
+	ApiCookieAuth,
 } from '@nestjs/swagger';
 import { PresenceService } from 'src/presence/presence.service';
 
 @ApiTags('Game')
 @Controller('game')
 export class GameController {
-  	constructor(
-    	private readonly gameService: GameService,
-    	private readonly usersService: UsersService,
-    	private readonly presenceService: PresenceService,
-  	) {}
+	constructor(
+		private readonly gameService: GameService,
+		private readonly usersService: UsersService,
+		private readonly presenceService: PresenceService,
+	) {}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Create a new game' })
-@ApiResponse({ status: 201, description: 'Game created, returns { gameId }' })
-@ApiResponse({ status: 401, description: 'Not authenticated' })
-@Post('create')
-async createGame(@Req() req: AuthRequest) {
-    const user = await this.usersService.getUser(req.user.sub);
-    const gameId = this.gameService.createGame(user);
-    await this.presenceService.emitFriendStatusChange(req.user.sub);
-    return { gameId };
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Create a new game' })
+	@ApiResponse({ status: 201, description: 'Game created, returns { gameId }' })
+	@ApiResponse({ status: 401, description: 'Not authenticated' })
+	@Post('create')
+	async createGame(@Req() req: AuthRequest) {
+		const user = await this.usersService.getUser(req.user.sub);
+		const gameId = this.gameService.createGame(user);
+		await this.presenceService.emitFriendStatusChange(req.user.sub);
+		return { gameId };
 	}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Get active game for the current user' })
-@ApiResponse({ status: 200, description: 'Returns the active game or null' })
-@ApiResponse({ status: 401, description: 'Not authenticated' })
-@Get('active')
-getActiveGame(@Req() req: AuthRequest) {
-    return this.gameService.getActiveGameByUserId(req.user.sub);
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Get active game for the current user' })
+	@ApiResponse({ status: 200, description: 'Returns the active game or null' })
+	@ApiResponse({ status: 401, description: 'Not authenticated' })
+	@Get('active')
+	getActiveGame(@Req() req: AuthRequest, @Res() res: Response) {
+		return res
+			.status(200)
+			.json(this.gameService.getActiveGameByUserId(req.user.sub));
 	}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Get all live games' })
-@ApiResponse({ status: 200, description: 'Returns list of live games' })
-@Get('liveGames')
-getLiveGames(@Req() req: AuthRequest) {
-    return this.gameService.getLiveGames(req.user.sub);
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Get all live games' })
+	@ApiResponse({ status: 200, description: 'Returns list of live games' })
+	@Get('liveGames')
+	getLiveGames(@Req() req: AuthRequest) {
+		return this.gameService.getLiveGames(req.user.sub);
 	}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Get a game by ID' })
-@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
-@ApiResponse({ status: 200, description: 'Returns the game state' })
-@ApiResponse({ status: 404, description: 'Game not found' })
-@Get(':id')
-getGame(@Param('id') gameId: string) {
-    return this.gameService.getGameById(gameId);
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Get a game by ID' })
+	@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
+	@ApiResponse({ status: 200, description: 'Returns the game state' })
+	@ApiResponse({ status: 404, description: 'Game not found' })
+	@Get(':id')
+	getGame(@Param('id') gameId: string) {
+		return this.gameService.getGameById(gameId);
 	}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Leave or cancel a game' })
-@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
-@ApiResponse({ status: 200, description: 'Successfully left the game' })
-@ApiResponse({ status: 400, description: 'Cannot cancel a game that is already in progress' })
-@ApiResponse({ status: 401, description: 'Not authenticated' })
-@ApiResponse({ status: 404, description: 'Game not found' })
-@Post(':id/leave')
-async leaveGame(@Param('id') gameId: string, @Req() req: AuthRequest) {
-	const result = this.gameService.leaveGame(gameId, req.user.sub);
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Leave or cancel a game' })
+	@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
+	@ApiResponse({ status: 200, description: 'Successfully left the game' })
+	@ApiResponse({
+		status: 400,
+		description: 'Cannot cancel a game that is already in progress',
+	})
+	@ApiResponse({ status: 401, description: 'Not authenticated' })
+	@ApiResponse({ status: 404, description: 'Game not found' })
+	@Post(':id/leave')
+	async leaveGame(@Param('id') gameId: string, @Req() req: AuthRequest) {
+		const result = this.gameService.leaveGame(gameId, req.user.sub);
 
-	await this.presenceService.emitFriendStatusChange(req.user.sub);
+		await this.presenceService.emitFriendStatusChange(req.user.sub);
 
-	return result;
-}
+		return result;
+	}
 
-@ApiCookieAuth()
-@ApiOperation({ summary: 'Get finished game history by game ID' })
-@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
-@ApiResponse({ status: 200, description: 'Returns match history' })
-@ApiResponse({ status: 400, description: 'Game is not finished yet' })
-@ApiResponse({ status: 404, description: 'Game not found' })
-@Get(':id/history')
-getFinishedGameHistory(@Param('id') gameId: string) {
-    return this.gameService.getFinishedGamesHistory(gameId);
+	@ApiCookieAuth()
+	@ApiOperation({ summary: 'Get finished game history by game ID' })
+	@ApiParam({ name: 'id', description: 'Game ID', example: 'game_abc123' })
+	@ApiResponse({ status: 200, description: 'Returns match history' })
+	@ApiResponse({ status: 400, description: 'Game is not finished yet' })
+	@ApiResponse({ status: 404, description: 'Game not found' })
+	@Get(':id/history')
+	getFinishedGameHistory(@Param('id') gameId: string) {
+		return this.gameService.getFinishedGamesHistory(gameId);
 	}
 }

--- a/backend/src/modules/game/game.gateway.ts
+++ b/backend/src/modules/game/game.gateway.ts
@@ -34,7 +34,7 @@ const allowedOrigins = trimmedOrigins.filter(function (origin) {
 		credentials: true,
 	},
 })
-@UseGuards(JwtAuthGuard) // TODO: verify if can delete (is no necessary bcz CALLED FOR APP)
+@UseGuards(JwtAuthGuard)
 export class GameGateway implements OnGatewayDisconnect {
 	@WebSocketServer()
 	server!: Namespace;
@@ -47,6 +47,11 @@ export class GameGateway implements OnGatewayDisconnect {
 		private readonly presenceService: PresenceService,
 	) {}
 
+	/**
+	 * Clears the stored turn timer for a game if one exists.
+	 *
+	 * @param gameId - Id of the game linked to the timer.
+	 */
 	private clearTurnTimer(gameId: string) {
 		const timer = this.turnTimers.get(gameId);
 
@@ -56,6 +61,13 @@ export class GameGateway implements OnGatewayDisconnect {
 		}
 	}
 
+	/**
+	 * Starts the backend turn timer for a playing game.
+	 * Frontend countdowns only mirror this server-side timestamp.
+	 *
+	 * @param gameId - Id of the game to time.
+	 * @param game - Current game state used to compute the remaining delay.
+	 */
 	private startTurnTimer(gameId: string, game: GameState) {
 		this.clearTurnTimer(gameId);
 
@@ -96,6 +108,13 @@ export class GameGateway implements OnGatewayDisconnect {
 		this.turnTimers.set(gameId, timer);
 	}
 
+	/**
+	 * Counts unique spectators currently connected to a game room.
+	 *
+	 * @param gameId - Id of the Socket.IO room.
+	 * @param game - Current game state used to exclude player seats.
+	 * @returns Number of unique connected users who are not players.
+	 */
 	private getSpectatorsCnt(gameId: string, game: GameState): number {
 		const room = this.server.adapter.rooms.get(gameId);
 		if (!room) return 0;
@@ -118,6 +137,11 @@ export class GameGateway implements OnGatewayDisconnect {
 		return userIdsInRoom.size;
 	}
 
+	/**
+	 * Deletes a finished game when no socket is still connected to its room.
+	 *
+	 * @param gameId - Id of the game to clean up.
+	 */
 	private cleanupFinishedGameIfEmpty(gameId: string) {
 		let game: GameState;
 
@@ -136,6 +160,13 @@ export class GameGateway implements OnGatewayDisconnect {
 		this.gameService.deleteGame(gameId);
 	}
 
+	/**
+	 * Sends the latest game state to every socket in the game room.
+	 * The spectator count is computed from connected sockets at emit time.
+	 *
+	 * @param gameId - Id of the game room.
+	 * @param game - Game state to broadcast.
+	 */
 	private emitGameUpdate(gameId: string, game: GameState) {
 		this.startTurnTimer(gameId, game);
 
@@ -145,6 +176,11 @@ export class GameGateway implements OnGatewayDisconnect {
 		});
 	}
 
+	/**
+	 * Sends the current X/O roles to player sockets after replay votes may swap seats.
+	 *
+	 * @param game - Game state containing the current player socket ids.
+	 */
 	private emitUpdatedRoles(game: GameState) {
 		const socketId_X = game.players.X.socketIds;
 		const socketId_O = game.players.O.socketIds;
@@ -155,6 +191,11 @@ export class GameGateway implements OnGatewayDisconnect {
 			this.server.to(socketId_O).emit('role_updated', { role: 'O' });
 	}
 
+	/**
+	 * Handles player and spectator disconnections from a game socket.
+	 *
+	 * @param client - Authenticated socket that disconnected.
+	 */
 	handleDisconnect(client: AuthSocket) {
 		const result = this.gameService.processPlayerDisconnection(client.id);
 		if (result) {
@@ -176,6 +217,12 @@ export class GameGateway implements OnGatewayDisconnect {
 		}
 	}
 
+	/**
+	 * Joins the authenticated user to a game room and broadcasts the updated state.
+	 *
+	 * @param body - Payload containing the game id to join.
+	 * @param client - Authenticated socket joining the game.
+	 */
 	@SubscribeMessage('join_game')
 	async handleJoinGame(
 		@MessageBody() body: { gameId: string },
@@ -216,6 +263,13 @@ export class GameGateway implements OnGatewayDisconnect {
 		}
 	}
 
+	/**
+	 * Applies a move from the authenticated player and broadcasts the new game state.
+	 *
+	 * @param body - Move payload containing the game id and board coordinates.
+	 * @param client - Authenticated socket sending the move.
+	 * @returns The updated game state when the move is accepted.
+	 */
 	@SubscribeMessage('play_move')
 	async handlePlayMove(
 		@MessageBody() body: PlayMoveDto,
@@ -249,6 +303,13 @@ export class GameGateway implements OnGatewayDisconnect {
 		}
 	}
 
+	/**
+	 * Registers a replay vote for the authenticated player.
+	 *
+	 * @param body - Payload containing the game id.
+	 * @param client - Authenticated socket requesting the replay.
+	 * @returns The updated game state after the replay vote.
+	 */
 	@SubscribeMessage('request_replay')
 	handleRequestReplay(
 		@MessageBody() body: { gameId: string },
@@ -268,6 +329,12 @@ export class GameGateway implements OnGatewayDisconnect {
 		}
 	}
 
+	/**
+	 * Removes the authenticated user from the game and updates the room state.
+	 *
+	 * @param body - Payload containing the game id to leave.
+	 * @param client - Authenticated socket leaving the game.
+	 */
 	@SubscribeMessage('leave_game')
 	async handleLeaveGame(
 		@MessageBody() body: { gameId: string },

--- a/backend/src/modules/game/game.logic.ts
+++ b/backend/src/modules/game/game.logic.ts
@@ -13,6 +13,11 @@ export function isCellEmpty(
 	return gameState.board[position.r][position.c] === null;
 }
 
+/**
+ * Creates the default in-memory state for a new game.
+ *
+ * @returns A waiting game state with an empty board and empty seats.
+ */
 export function initGameState(): GameState {
 	return {
 		board: createEmptyBoard(BOARD_SIZE),
@@ -84,6 +89,14 @@ export function checkDraw(countMoves: number): boolean {
 	return false;
 }
 
+/**
+ * Checks that a move targets a valid empty cell before it is applied.
+ *
+ * @param gameState - Current game state.
+ * @param r - Board row selected by the player.
+ * @param c - Board column selected by the player.
+ * @throws When the target cell is outside the board or already occupied.
+ */
 export function validateToMove(gameState: GameState, r: number, c: number) {
 	const size = gameState.board.length;
 	if (r < 0 || r >= size || c < 0 || c >= size)
@@ -110,6 +123,14 @@ export function createEmptyBoard(size: number = BOARD_SIZE): CellValue[][] {
 	return board;
 }
 
+/**
+ * Applies an accepted move, updates the disappearing-cell rule, and finishes the game if needed.
+ *
+ * @param game - Current in-memory game state.
+ * @param r - Board row selected by the player.
+ * @param c - Board column selected by the player.
+ * @returns The same game state after applying the move.
+ */
 export function applyMove(game: GameState, r: number, c: number): GameState {
 	const symbol = game.currentPlayer;
 
@@ -149,14 +170,12 @@ export function applyMove(game: GameState, r: number, c: number): GameState {
 }
 
 /**
- * (SETTER)
- * Assign a role to the client
- * - 1st client: X
- * - 2nd client: O (starts the game)
- * - others: spectator
- * @param game - The game state
- * @param clientId - The client identifier
- * @return PlayerRole The assigned player role
+ * Keeps a reconnecting user in the same seat; new users fill X, then O, then become spectators.
+ *
+ * @param game - Current in-memory game state.
+ * @param userId - Id of the user joining or reconnecting.
+ * @param socketId - Socket id used for this connection.
+ * @returns The role assigned to this socket.
  */
 export function assignPlayerRole(
 	game: GameState,
@@ -210,6 +229,12 @@ export function posToIdx(pos: BoardPosition): number {
 	return pos.r * 3 + pos.c;
 }
 
+/**
+ * Starts a replay from a clean board and swaps seats so the previous O player starts as X.
+ *
+ * @param game - Finished game state that both players agreed to replay.
+ * @returns The same game state reset for the replay.
+ */
 export function resetBoardForReplay(game: GameState): GameState {
 	game.board = createEmptyBoard(BOARD_SIZE);
 	game.currentPlayer = 'X';

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -55,6 +55,12 @@ export class GameService {
 		return null;
 	}
 
+	/**
+	 * Creates a waiting game and reserves the X seat for the current user.
+	 *
+	 * @param user - Public profile of the user creating the game.
+	 * @returns Id of the newly created game.
+	 */
 	createGame(user: PublicPlayerProfile): string {
 		const active = this.findActiveGameByUserId(user.id);
 		if (active) throw new ConflictException('ERR_GAME_ALREADY_ACTIVE');
@@ -71,8 +77,12 @@ export class GameService {
 		return gameId;
 	}
 
-	/*
-	 * - !!!return a copy of game
+	/**
+	 * Returns a cloned game state so callers cannot mutate the active game directly.
+	 *
+	 * @param gameId - Id of the game to read.
+	 * @returns A copy of the current game state.
+	 * @throws When the game does not exist.
 	 */
 	getGameById(gameId: string): GameState {
 		const game = this.activeGame.get(gameId);
@@ -94,6 +104,12 @@ export class GameService {
 		};
 	}
 
+	/**
+	 * Builds the active game summary used by the frontend lobby cards.
+	 *
+	 * @param userId - Id of the user asking for their active game.
+	 * @returns The active game summary, or null when the user is free.
+	 */
 	getActiveGameByUserId(userId: number) {
 		const active = this.findActiveGameByUserId(userId);
 		if (!active) return null;
@@ -145,6 +161,15 @@ export class GameService {
 		return 'available';
 	}
 
+	/**
+	 * Adds a socket to a game and assigns the user as X, O, or spectator.
+	 *
+	 * @param gameId - Id of the game to join.
+	 * @param socketId - Socket id joining the game.
+	 * @param userId - Id of the authenticated user.
+	 * @param user - Public profile used for player seats.
+	 * @returns The updated game state and assigned role.
+	 */
 	joinGame(
 		gameId: string,
 		socketId: string,
@@ -190,6 +215,14 @@ export class GameService {
 		return { game, role };
 	}
 
+	/**
+	 * Registers a replay vote and resets the board when both players agree.
+	 *
+	 * @param gameId - Id of the finished game.
+	 * @param userId - Id of the user voting for replay.
+	 * @returns The updated game state after the vote.
+	 * @throws When the game is not finished or the user is a spectator.
+	 */
 	requestReplay(gameId: string, userId: number): GameState {
 		const game = this.getMutableGameById(gameId);
 
@@ -209,6 +242,16 @@ export class GameService {
 		return game;
 	}
 
+	/**
+	 * Validates and applies a player move, including turn timeout checks.
+	 *
+	 * @param gameId - Id of the game being played.
+	 * @param userId - Id of the player sending the move.
+	 * @param r - Board row selected by the player.
+	 * @param c - Board column selected by the player.
+	 * @returns The updated game state after the move or timeout.
+	 * @throws When the user cannot play this move.
+	 */
 	async playMove(
 		gameId: string,
 		userId: number,
@@ -228,7 +271,6 @@ export class GameService {
 		const now = Date.now();
 		const timeOnClick = now - game.lastMove;
 
-		// 30 SEC
 		if (timeOnClick > TURN_TIMEOUT_MS) {
 			const timeOutGame = await this.finalizeTurnTimeout(gameId);
 			if (timeOutGame) return timeOutGame;
@@ -260,6 +302,12 @@ export class GameService {
 		return updatState;
 	}
 
+	/**
+	 * Removes one socket and reports a player disconnect only after all their sockets close.
+	 *
+	 * @param socketId - Socket id that disconnected.
+	 * @returns The disconnected player and game, or null if the user still has another socket.
+	 */
 	processPlayerDisconnection(
 		socketId: string,
 	): { gameId: string; role: 'X' | 'O'; game: GameState } | null {
@@ -313,6 +361,12 @@ export class GameService {
 		await this.matchService.recordMatch(data, game.movesGameHistory);
 	}
 
+	/**
+	 * Ends the game when the current player exceeds the turn timer and persists the result.
+	 *
+	 * @param gameId - Id of the game to check.
+	 * @returns The finished game state, or null if the timeout should not fire.
+	 */
 	async finalizeTurnTimeout(gameId: string): Promise<GameState | null> {
 		const game = this.getMutableGameById(gameId);
 		if (game.status !== 'playing') return null;
@@ -356,6 +410,12 @@ export class GameService {
 		return game;
 	}
 
+	/**
+	 * Lists games the current user can join or spectate.
+	 *
+	 * @param userId - Id of the current user.
+	 * @returns Waiting and playing games that do not already include this user.
+	 */
 	getLiveGames(userId: number) {
 		const waiting: { gameId: string; playerX: PublicPlayerProfile | null }[] =
 			[];
@@ -382,6 +442,14 @@ export class GameService {
 		return { waiting, playing };
 	}
 
+	/**
+	 * Cancels a waiting game or marks a finished game as left by a player.
+	 *
+	 * @param gameId - Id of the game to leave.
+	 * @param userId - Id of the user leaving the game.
+	 * @returns Whether the game was deleted and the remaining game state if any.
+	 * @throws When the user tries to leave a game that is still playing.
+	 */
 	leaveGame(
 		gameId: string,
 		userId: number,

--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -8,13 +8,7 @@ import {
 	NotFoundException,
 } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import {
-	GameState,
-	PlayerRole,
-	PlayerSymbol,
-	PublicPlayerProfile,
-	SocketIds,
-} from './game.types';
+import { GameState, PlayerRole, PublicPlayerProfile } from './game.types';
 import { MatchesService } from './matches.service';
 import {
 	initGameState,
@@ -293,13 +287,13 @@ export class GameService {
 		return this.activeGame.delete(gameId);
 	}
 
-/**
- * Persists a completed game to the database.
- * Maps the in-memory game state (X/O players) to the MatchesService format
- * before delegating the storage operation.
- *
- * @param game - The finished game state containing players, scores, and move history.
- */
+	/**
+	 * Persists a completed game to the database.
+	 * Maps the in-memory game state (X/O players) to the MatchesService format
+	 * before delegating the storage operation.
+	 *
+	 * @param game - The finished game state containing players, scores, and move history.
+	 */
 	private async saveGameToDB(game: GameState) {
 		if (!game.playerProfiles.X || !game.playerProfiles.O) return;
 

--- a/backend/src/modules/game/game.types.ts
+++ b/backend/src/modules/game/game.types.ts
@@ -32,10 +32,6 @@ export interface BoardPosition {
 	c: number;
 }
 
-export interface Move extends BoardPosition {
-	player: PlayerSymbol;
-}
-
 export interface PlayerSeat {
 	ownerUserId: number | null;
 	socketIds: SocketIds;

--- a/frontend/src/components/BasicChat.tsx
+++ b/frontend/src/components/BasicChat.tsx
@@ -4,6 +4,7 @@ import { io, type Socket } from 'socket.io-client';
 import type { ChatMessage } from '@/type/user.types';
 import { useTranslation } from 'react-i18next';
 import { EasterEggPanel, type EasterEgg } from './easter-eggs/EasterEggPanel';
+import { basicChatClasses } from '@/styles/gameChatClasses';
 
 type BasicChatProps = {
 	onClose: () => void;
@@ -99,18 +100,18 @@ export function BasicChat({ onClose }: BasicChatProps) {
 	}
 
 	return (
-		<section className="flex flex-col h-full w-full max-w-[320px] overflow-hidden">
+		<section className={basicChatClasses.container}>
 			<div className="flex justify-between items-center p-2">
 				<div className="flex items-center gap-2">
 					<h1>Chat</h1>
 					<span className="relative flex size-3">
 						{connected ? (
 							<>
-								<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-700 opacity-75"></span>
-								<span className="relative inline-flex size-3 rounded-full bg-green-600"></span>
+								<span className={basicChatClasses.onlinePing}></span>
+								<span className={basicChatClasses.onlineDot}></span>
 							</>
 						) : (
-							<span className="relative inline-flex size-3 rounded-full bg-red-500"></span>
+							<span className={basicChatClasses.offlineDot}></span>
 						)}
 					</span>
 				</div>
@@ -135,7 +136,7 @@ export function BasicChat({ onClose }: BasicChatProps) {
 							</span>
 						</div>
 
-						<div className="min-w-0 max-w-full whitespace-pre-wrap wrap-anywhere text-sm leading-snug text-white">
+						<div className={basicChatClasses.messageText}>
 							{message.content}
 						</div>
 					</div>

--- a/frontend/src/components/BasicChat.tsx
+++ b/frontend/src/components/BasicChat.tsx
@@ -3,13 +3,14 @@ import { Button } from './ui/Button';
 import { io, type Socket } from 'socket.io-client';
 import type { ChatMessage } from '@/type/user.types';
 import { useTranslation } from 'react-i18next';
-import {
-	EasterEggPanel,
-	type EasterEgg,
-} from "./easter-eggs/EasterEggPanel";
+import { EasterEggPanel, type EasterEgg } from './easter-eggs/EasterEggPanel';
 
 type BasicChatProps = {
 	onClose: () => void;
+};
+
+type ChatException = {
+	message?: string | string[];
 };
 
 export function BasicChat({ onClose }: BasicChatProps) {
@@ -21,7 +22,7 @@ export function BasicChat({ onClose }: BasicChatProps) {
 
 	const [easterEgg, setEasterEgg] = useState<EasterEgg | null>(null);
 
-	const { t } = useTranslation()
+	const { t } = useTranslation();
 
 	useEffect(() => {
 		const client = io(`${window.location.origin}/chat`, {
@@ -36,16 +37,16 @@ export function BasicChat({ onClose }: BasicChatProps) {
 		});
 		client.on('disconnect', () => setConnected(false));
 
-		client.on('chat_message', (message) => {
+		client.on('chat_message', (message: ChatMessage) => {
 			setMessages((prev) => [...prev, message]);
 		});
 
-		client.on('connect_error', (error) => {
+		client.on('connect_error', (error: Error) => {
 			console.error('chat socket error:', error.message);
 		});
 
-		client.on('chat_error', (error) => {
-			console.error('Error:', error.error);
+		client.on('exception', (error: ChatException) => {
+			console.error('Chat exception:', error.message);
 		});
 
 		return () => {
@@ -62,10 +63,10 @@ export function BasicChat({ onClose }: BasicChatProps) {
 		const command = text.toLowerCase();
 
 		const commands: Record<string, EasterEgg> = {
-			"/rick": "rick",
-			"/matrix": "matrix",
-			"/neofetch": "neofetch",
-			"/nuke": "nuke",
+			'/rick': 'rick',
+			'/matrix': 'matrix',
+			'/neofetch': 'neofetch',
+			'/nuke': 'nuke',
 		};
 
 		const egg = commands[command];
@@ -75,14 +76,14 @@ export function BasicChat({ onClose }: BasicChatProps) {
 		}
 
 		setEasterEgg(egg);
-		setContent("");
+		setContent('');
 		return true;
 	}
 
 	function sendMessage() {
 		const text = content.trim();
 
-		if (!clientRef.current || text.length === 0) {
+		if (!clientRef.current || !connected || text.length === 0) {
 			return;
 		}
 
@@ -141,15 +142,11 @@ export function BasicChat({ onClose }: BasicChatProps) {
 				))}
 
 				{easterEgg && (
-					<EasterEggPanel
-						type={easterEgg}
-						onClose={() => setEasterEgg(null)}
-					/>
+					<EasterEggPanel type={easterEgg} onClose={() => setEasterEgg(null)} />
 				)}
 
 				<div ref={bottomRef} />
 			</div>
-
 
 			<div className="flex items-end gap-2 p-2">
 				<textarea
@@ -162,6 +159,7 @@ export function BasicChat({ onClose }: BasicChatProps) {
 						}
 					}}
 					placeholder={t('chat.placeholder', { count: 500 })}
+					maxLength={500}
 					rows={4}
 					className="flex-1 border p-2 resize-none"
 				/>

--- a/frontend/src/components/game/Board.tsx
+++ b/frontend/src/components/game/Board.tsx
@@ -51,6 +51,12 @@ export default function Board() {
 		oldOppDiscnct.current = opponentDisconnect;
 	}, [opponentDisconnect, t]);
 
+	useEffect(() => {
+		if (game?.status === 'waiting' && playerRole === 'X') {
+			navigate('/play');
+		}
+	}, [game?.status, playerRole, navigate]);
+
 	if (error && !game) {
 		return (
 			<div className="text-white text-center p-8">
@@ -73,9 +79,6 @@ export default function Board() {
 		);
 	}
 
-	if (game.status === 'waiting' && playerRole === 'X') {
-		navigate('/play');
-	}
 	const { board, currentPlayer, status, winner, toDisapear } = game;
 
 	const playerXName = game.playerProfiles?.X?.username || 'Player X';

--- a/frontend/src/components/game/Board.tsx
+++ b/frontend/src/components/game/Board.tsx
@@ -15,6 +15,7 @@ import { GameStatusBanner } from './GameStatusBanner';
 import { EndGamePopup } from './EndGamePopup';
 import { SpectatorCount } from './SpectatorCount';
 import { Button } from '@/components/ui/Button';
+import { boardClasses } from '@/styles/gameChatClasses';
 
 export default function Board() {
 	const { game, error, playMove, playerRole, requestReplay, leaveGame } =
@@ -68,7 +69,7 @@ export default function Board() {
 
 	if (!game) {
 		return (
-			<section className="w-full max-w-3xl mx-auto px-6 py-10 text-white">
+			<section className={boardClasses.emptyState}>
 				<EmptyStateCard
 					title={t('game.title')}
 					icon={<Gamepad2 size={24} />}
@@ -110,10 +111,10 @@ export default function Board() {
 	);
 
 	return (
-		<div className="w-full max-w-5xl overflow-x-hidden rounded-2xl border border-white/10 bg-slate-900/80 p-4 shadow-2xl sm:p-6 xl:p-8">
-			<div className="grid w-full min-w-0 grid-cols-1 items-start justify-items-center gap-6 text-center xl:grid-cols-[1fr_auto_1fr]">
+		<div className={boardClasses.card}>
+			<div className={boardClasses.layout}>
 				{/* play area*/}
-				<div className="flex w-full min-w-0 max-w-96 flex-col items-center xl:col-start-2">
+				<div className={boardClasses.playArea}>
 					<PlayerCards
 						playerXName={playerXName}
 						playerOName={playerOName}
@@ -131,7 +132,7 @@ export default function Board() {
 						opponentDisconnect={opponentDisconnect}
 					/>
 
-					<div className="grid w-full max-w-96 grid-cols-3 gap-3 rounded-2xl border border-white/10 bg-black/20 p-4 sm:p-8">
+					<div className={boardClasses.boardGrid}>
 						{flatBoard.map((value, i) => (
 							<Square
 								key={i}
@@ -149,13 +150,13 @@ export default function Board() {
 						))}
 					</div>
 
-					<div className="mt-6 text-white/60 font-medium">
+					<div className={boardClasses.spectatorArea}>
 						<SpectatorCount count={game.spectatCnt} />
 					</div>
 				</div>
 
 				{/* Popup Replay */}
-				<div className="w-full min-w-0 max-w-80 xl:col-start-3 xl:justify-self-start">
+				<div className={boardClasses.popupArea}>
 					{showPopup && (
 						<EndGamePopup
 							endGameMessage={endGameMessage}

--- a/frontend/src/components/game/Board.tsx
+++ b/frontend/src/components/game/Board.tsx
@@ -125,8 +125,6 @@ export default function Board() {
 						error={error}
 						status={status}
 						playerRole={playerRole}
-						canPlay={canPlay}
-						hasReplayRole={hasReplayRole}
 						opponentDisconnect={opponentDisconnect}
 					/>
 

--- a/frontend/src/components/game/EndGamePopup.tsx
+++ b/frontend/src/components/game/EndGamePopup.tsx
@@ -5,6 +5,7 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { Username } from '@/components/ui/Username';
 import { useEffect, useRef } from 'react';
+import { endGamePopupClasses } from '@/styles/gameChatClasses';
 
 type Props = {
 	endGameMessage: EndGameMessage;
@@ -47,16 +48,16 @@ export function EndGamePopup({
 	}, [endGameMessage.winnerName, playWinSound]);
 
 	return (
-		<Card className="flex min-w-80 max-w-[90vw] flex-col items-center gap-4 bg-slate-900 p-8 text-white hover:scale-100">
+		<Card className={endGamePopupClasses.card}>
 			<h2
-				className={`flex max-w-full items-center justify-center gap-2 text-center text-2xl font-bold ${endGameMessage.color}`}
+				className={`${endGamePopupClasses.title} ${endGameMessage.color}`}
 			>
 				{endGameMessage.winnerName ? (
 					<>
 						<Username
 							name={endGameMessage.winnerName}
 							variant="card"
-							className="max-w-32 font-bold"
+							className={endGamePopupClasses.winnerName}
 						/>
 						<span>{endGameMessage.resultText}</span>
 					</>
@@ -65,34 +66,34 @@ export function EndGamePopup({
 				)}
 			</h2>
 
-			<p className="text-center text-sm font-medium text-white/70">
+			<p className={endGamePopupClasses.subtitle}>
 				{endGameMessage.subtitle}
 			</p>
 
 			{canReplay ? (
-				<div className="flex flex-col items-center gap-3">
+				<div className={endGamePopupClasses.replayActions}>
 					<Button onClick={requestReplay} disabled={hasVoted}>
 						{waitingReplayOtherPlayer
 							? t('game.waiting', { defaultValue: 'Waiting...' })
 							: t('game.replay', { defaultValue: 'REPLAY' })}
 					</Button>
 
-					<div className="flex gap-2 text-xs font-bold">
+					<div className={endGamePopupClasses.replayVotes}>
 						<span
-							className={`rounded-full border px-3 py-1 ${
+							className={`${endGamePopupClasses.vote} ${
 								replayVotes.X
-									? 'border-cyan-400 text-cyan-400'
-									: 'border-white/10 text-white/40'
+									? endGamePopupClasses.voteXActive
+									: endGamePopupClasses.voteInactive
 							}`}
 						>
 							X {replayVotes.X ? '✓' : ''}
 						</span>
 
 						<span
-							className={`rounded-full border px-3 py-1 ${
+							className={`${endGamePopupClasses.vote} ${
 								replayVotes.O
-									? 'border-fuchsia-400 text-fuchsia-400'
-									: 'border-white/10 text-white/40'
+									? endGamePopupClasses.voteOActive
+									: endGamePopupClasses.voteInactive
 							}`}
 						>
 							O {replayVotes.O ? '✓' : ''}
@@ -100,7 +101,7 @@ export function EndGamePopup({
 					</div>
 				</div>
 			) : (
-				<p className="text-center text-sm text-white/50">
+				<p className={endGamePopupClasses.disabledReplayText}>
 					{playerLeft
 						? t('game.end.opponentLeftReplay')
 						: t('game.end.decidingReplay')}

--- a/frontend/src/components/game/GameStatusBanner.tsx
+++ b/frontend/src/components/game/GameStatusBanner.tsx
@@ -1,5 +1,6 @@
 import type { GameStatus, PlayerRole } from '@/type/game.types';
 import { useTranslation } from 'react-i18next';
+import { gameStatusBannerClasses } from '@/styles/gameChatClasses';
 
 type Props = {
 	error: string | null;
@@ -18,7 +19,7 @@ export function GameStatusBanner({
 	return (
 		<div>
 			{error && (
-				<div className="mb-4 rounded-lg border border-red-400 bg-red-500/20 px-4 py-3 text-red-200">
+				<div className={gameStatusBannerClasses.error}>
 					{error}
 				</div>
 			)}
@@ -30,7 +31,7 @@ export function GameStatusBanner({
 			)}
 
 			{status === 'playing' && opponentDisconnect && (
-				<div className="border border-orange-400 bg-orange-500/20 px-4 py-3 text-orange-100">
+				<div className={gameStatusBannerClasses.disconnect}>
 					{t('game.opponentDisconnect')}
 				</div>
 			)}

--- a/frontend/src/components/game/GameStatusBanner.tsx
+++ b/frontend/src/components/game/GameStatusBanner.tsx
@@ -5,8 +5,6 @@ type Props = {
 	error: string | null;
 	status: GameStatus | null;
 	playerRole: PlayerRole | null;
-	canPlay: boolean;
-	hasReplayRole: boolean;
 	opponentDisconnect: boolean;
 };
 

--- a/frontend/src/components/game/PlayerCards.tsx
+++ b/frontend/src/components/game/PlayerCards.tsx
@@ -28,8 +28,8 @@ function PlayerSymbolIcon({ symbol }: { symbol: PlayerSymbol }) {
 	const color = symbol === 'X' ? 'text-cyan-400' : 'text-fuchsia-400';
 
 	return (
-		<span className="grid h-6 w-6 shrink-0 place-items-center rounded-full border border-white/10 bg-white/5">
-			<Icon className={`h-4 w-4 stroke-3 ${color}`} />
+		<span className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-white/10 bg-white/5 sm:h-6 sm:w-6">
+			<Icon className={`h-3.5 w-3.5 stroke-3 sm:h-4 sm:w-4 ${color}`} />
 		</span>
 	);
 }
@@ -44,23 +44,23 @@ function PlayerCard({
 	const { t } = useTranslation();
 
 	return (
-		<div className="relative mt-4">
+		<div className="relative mt-2 sm:mt-4">
 			{isYou && (
-				<span className="absolute inset-x-0 -top-6 text-center text-xs font-bold uppercase text-cyan-400">
+				<span className="absolute inset-x-0 -top-4 text-center text-[10px] font-bold uppercase text-cyan-400 sm:-top-6 sm:text-xs">
 					{t('game.you')}
 				</span>
 			)}
 			<Card
-				className={`flex w-28 flex-col items-center p-3
-	        ${isActive ? 'ring-2 ring-cyan-400' : ''}`}
+				className={`flex w-24 flex-col items-center p-2 sm:w-28 sm:p-3
+				${isActive ? 'ring-2 ring-cyan-400' : ''}`}
 			>
 				<Avatar src={avatar} alt={`player ${symbol}`} fallback={name[0]} />
-				<div className="mt-3 flex w-full min-w-0 items-center justify-center gap-1 font-bold">
+				<div className="mt-2 flex w-full min-w-0 items-center justify-center gap-1 font-bold sm:mt-3">
 					<PlayerSymbolIcon symbol={symbol} />
 					<Username
 						name={name}
 						variant="card"
-						className="text-xs max-w-14 font-bold"
+						className="max-w-10 text-[11px] font-bold sm:max-w-14 sm:text-xs"
 					/>
 				</div>
 			</Card>
@@ -80,7 +80,7 @@ export function PlayerCards({
 	const percentage = Math.max(0, Math.min(100, (timeLeft / 30) * 100));
 
 	return (
-		<div className="mb-8 flex w-full max-w-96 items-center justify-between text-white">
+		<div className="mb-3 flex w-full max-w-[280px] items-center justify-between text-white sm:mb-8 sm:max-w-96">
 			<PlayerCard
 				symbol="X"
 				name={playerXName}
@@ -90,7 +90,7 @@ export function PlayerCards({
 			/>
 
 			<div
-				className="grid size-16 place-items-center rounded-full text-sm font-bold"
+				className="grid size-11 place-items-center rounded-full text-xs font-bold sm:size-16 sm:text-sm"
 				style={{
 					background: `radial-gradient(#111827 65%, #0000 0), 
                conic-gradient(${percentage > 30 ? `#22d300` : '#ef4444'} ${percentage}%, #0000 0)`,

--- a/frontend/src/components/game/PlayerCards.tsx
+++ b/frontend/src/components/game/PlayerCards.tsx
@@ -4,6 +4,7 @@ import { Card } from '../ui/Card';
 import { Circle, X } from 'lucide-react';
 import type { PlayerRole, PlayerSymbol } from '@/type/game.types';
 import { useTranslation } from 'react-i18next';
+import { playerCardsClasses } from '@/styles/gameChatClasses';
 
 type PlayerCardProps = {
 	symbol: PlayerSymbol;
@@ -28,8 +29,8 @@ function PlayerSymbolIcon({ symbol }: { symbol: PlayerSymbol }) {
 	const color = symbol === 'X' ? 'text-cyan-400' : 'text-fuchsia-400';
 
 	return (
-		<span className="grid h-5 w-5 shrink-0 place-items-center rounded-full border border-white/10 bg-white/5 sm:h-6 sm:w-6">
-			<Icon className={`h-3.5 w-3.5 stroke-3 sm:h-4 sm:w-4 ${color}`} />
+		<span className={playerCardsClasses.symbolBadge}>
+			<Icon className={`${playerCardsClasses.symbolIcon} ${color}`} />
 		</span>
 	);
 }
@@ -46,21 +47,22 @@ function PlayerCard({
 	return (
 		<div className="relative mt-2 sm:mt-4">
 			{isYou && (
-				<span className="absolute inset-x-0 -top-4 text-center text-[10px] font-bold uppercase text-cyan-400 sm:-top-6 sm:text-xs">
+				<span className={playerCardsClasses.youLabel}>
 					{t('game.you')}
 				</span>
 			)}
 			<Card
-				className={`flex w-24 flex-col items-center p-2 sm:w-28 sm:p-3
-				${isActive ? 'ring-2 ring-cyan-400' : ''}`}
+				className={`${playerCardsClasses.card} ${
+					isActive ? playerCardsClasses.activeCard : ''
+				}`}
 			>
 				<Avatar src={avatar} alt={`player ${symbol}`} fallback={name[0]} />
-				<div className="mt-2 flex w-full min-w-0 items-center justify-center gap-1 font-bold sm:mt-3">
+				<div className={playerCardsClasses.nameRow}>
 					<PlayerSymbolIcon symbol={symbol} />
 					<Username
 						name={name}
 						variant="card"
-						className="max-w-10 text-[11px] font-bold sm:max-w-14 sm:text-xs"
+						className={playerCardsClasses.name}
 					/>
 				</div>
 			</Card>
@@ -80,7 +82,7 @@ export function PlayerCards({
 	const percentage = Math.max(0, Math.min(100, (timeLeft / 30) * 100));
 
 	return (
-		<div className="mb-3 flex w-full max-w-[280px] items-center justify-between text-white sm:mb-8 sm:max-w-96">
+		<div className={playerCardsClasses.container}>
 			<PlayerCard
 				symbol="X"
 				name={playerXName}
@@ -90,7 +92,7 @@ export function PlayerCards({
 			/>
 
 			<div
-				className="grid size-11 place-items-center rounded-full text-xs font-bold sm:size-16 sm:text-sm"
+				className={playerCardsClasses.timer}
 				style={{
 					background: `radial-gradient(#111827 65%, #0000 0), 
                conic-gradient(${percentage > 30 ? `#22d300` : '#ef4444'} ${percentage}%, #0000 0)`,

--- a/frontend/src/components/game/SpectatorCount.tsx
+++ b/frontend/src/components/game/SpectatorCount.tsx
@@ -1,5 +1,6 @@
 import { Eye } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { spectatorCountClasses } from '@/styles/gameChatClasses';
 
 type Props = {
 	count: number;
@@ -10,7 +11,7 @@ export function SpectatorCount({ count }: Props) {
 	if (count <= 0) return null;
 
 	return (
-		<div className="mb-2 flex items-center justify-center gap-1 text-xs text-white/60">
+		<div className={spectatorCountClasses.container}>
 			<Eye size={14} />
 
 			<span>

--- a/frontend/src/components/game/Square.tsx
+++ b/frontend/src/components/game/Square.tsx
@@ -1,4 +1,5 @@
 import type { CellValue } from "../../type/game.types";
+import { squareClasses } from "@/styles/gameChatClasses";
 
 type SquareProps = {
   value: CellValue;
@@ -13,15 +14,13 @@ export default function Square({
 }: SquareProps) {
   return (
     <button
-      className="aspect-square w-full rounded-xl border border-white/40 bg-white/10 text-7xl font-bold shadow-md active:scale-95 hover:bg-white/20 transition-all flex items-center justify-center"
+      className={squareClasses.button}
       onClick={onSquareClick}
     >
       <span
-        className={`
-          ${value === "X" ? "text-cyan-400" : "text-fuchsia-400"}
-          ${isWarning ? "opacity-30 scale-75" : "opacity-100"}
-          transition-all duration-300
-        `}
+        className={`${squareClasses.value} ${
+          value === "X" ? squareClasses.xValue : squareClasses.oValue
+        } ${isWarning ? squareClasses.warning : squareClasses.normal}`}
       >
         {value ?? ""}
       </span>

--- a/frontend/src/components/game/boardHelpers.tsx
+++ b/frontend/src/components/game/boardHelpers.tsx
@@ -8,6 +8,15 @@ export type EndGameMessage = {
 	color: string;
 };
 
+/**
+ * Builds the message shown in the end-game popup.
+ *
+ * @param endReason - Reason why the game finished.
+ * @param winner - Symbol of the winner, or null for a draw.
+ * @param playerXName - Display name of the X player.
+ * @param playerOName - Display name of the O player.
+ * @returns Text and color data used by the popup.
+ */
 export function getEndGameMessage(
 	endReason: EndReason,
 	winner: CellValue,

--- a/frontend/src/components/hooks/useGameTimer.ts
+++ b/frontend/src/components/hooks/useGameTimer.ts
@@ -3,6 +3,12 @@ import { useEffect, useState } from "react";
 
 const TURN_TIMEOUT_SECONDS = 30;
 
+/**
+ * Mirrors the backend turn timer from the game timestamp.
+ *
+ * @param game - Current game state received from the socket.
+ * @returns Seconds left for the current turn.
+ */
 export function useGameTimer(game: GameState | null) {
   const [timeLeft, setTimeLeft] = useState(TURN_TIMEOUT_SECONDS);
 

--- a/frontend/src/lib/gameErrorMsg.ts
+++ b/frontend/src/lib/gameErrorMsg.ts
@@ -1,9 +1,22 @@
 import i18n from "@/i18n/config";
 
+/**
+ * Maps backend game errors to messages that can be shown in the UI.
+ *
+ * @param rawMessage - Error message or code received from the game socket.
+ * @returns A readable game error message.
+ */
 export function gameErrorMsg(rawMessage: string | null | undefined): string {
   if (!rawMessage) return i18n.t("errors.game.default");
 
-  const message = rawMessage.toLowerCase();
+  const raw = rawMessage.trim();
+  if (!raw) return i18n.t("errors.game.default");
+
+  const message = raw.toLowerCase();
+
+  if (raw.startsWith("ERR_GAME_") && i18n.exists(raw)) {
+    return i18n.t(raw);
+  }
 
   if (message.includes("user not found")) {
     return i18n.t("errors.game.userNotFound");
@@ -45,5 +58,5 @@ export function gameErrorMsg(rawMessage: string | null | undefined): string {
     return i18n.t("errors.game.unknown");
   }
 
-  return rawMessage;
+  return raw;
 }

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -68,7 +68,7 @@ export default function Game() {
 	}, [gameId]);
 
 	return (
-		<div className="flex justify-center items-start min-h-screen pt-8">
+		<div className="flex justify-center items-start pt-1 pb-20 sm:pt-8 sm:pb-8">
 			<Board />
 		</div>
 	);

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -6,6 +6,7 @@ import { useGameStore } from '../Store/gameStore';
 import { gameErrorMsg } from '@/lib/gameErrorMsg';
 import type { GameState, PlayerRole } from '@/type/game.types';
 import i18n from '@/i18n/config';
+import { gamePageClasses } from '@/styles/gameChatClasses';
 
 type JoinedAsPayload = {
 	role: PlayerRole;
@@ -68,7 +69,7 @@ export default function Game() {
 	}, [gameId]);
 
 	return (
-		<div className="flex justify-center items-start pt-1 pb-20 sm:pt-8 sm:pb-8">
+		<div className={gamePageClasses.container}>
 			<Board />
 		</div>
 	);

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -4,6 +4,16 @@ import { io } from 'socket.io-client';
 import { useParams } from 'react-router-dom';
 import { useGameStore } from '../Store/gameStore';
 import { gameErrorMsg } from '@/lib/gameErrorMsg';
+import type { GameState, PlayerRole } from '@/type/game.types';
+import i18n from '@/i18n/config';
+
+type JoinedAsPayload = {
+	role: PlayerRole;
+};
+
+type GameErrorPayload = {
+	message: string;
+};
 
 export default function Game() {
 	const { gameId } = useParams<{ gameId: string }>();
@@ -24,23 +34,23 @@ export default function Game() {
 			client.emit('join_game', { gameId });
 		});
 
-		client.on('joined_as', (payload) => {
+		client.on('joined_as', (payload: JoinedAsPayload) => {
 			useGameStore.getState().setPlayerRole(payload.role);
 		});
 
-		client.on('connect_error', (error) =>
-			console.error('connexion error:', error.message, error),
+		client.on('connect_error', () =>
+			useGameStore.getState().setError(i18n.t('errors.game.default')),
 		);
 
-		client.on('game_updated', (payload) => {
+		client.on('game_updated', (payload: GameState) => {
 			useGameStore.getState().syncFromServer(payload);
 		});
 
-		client.on('role_updated', (payload) => {
+		client.on('role_updated', (payload: JoinedAsPayload) => {
 			useGameStore.getState().setPlayerRole(payload.role);
 		});
 
-		client.on('game_error', (payload) => {
+		client.on('game_error', (payload: GameErrorPayload) => {
 			const message = gameErrorMsg(payload.message);
 
 			if (message === 'Game not found') {

--- a/frontend/src/styles/gameChatClasses.ts
+++ b/frontend/src/styles/gameChatClasses.ts
@@ -1,0 +1,82 @@
+export const gamePageClasses = {
+	container: 'flex justify-center items-start pt-1 pb-20 sm:pt-8 sm:pb-8',
+} as const;
+
+export const basicChatClasses = {
+	container: 'flex flex-col h-full w-full max-w-[320px] overflow-hidden',
+	onlinePing:
+		'absolute inline-flex h-full w-full animate-ping rounded-full bg-green-700 opacity-75',
+	onlineDot: 'relative inline-flex size-3 rounded-full bg-green-600',
+	offlineDot: 'relative inline-flex size-3 rounded-full bg-red-500',
+	messageText:
+		'min-w-0 max-w-full whitespace-pre-wrap wrap-anywhere text-sm leading-snug text-white',
+} as const;
+
+export const boardClasses = {
+	emptyState: 'w-full max-w-3xl mx-auto px-6 py-10 text-white',
+	card:
+		'w-full max-w-5xl overflow-x-hidden rounded-2xl border border-white/10 bg-slate-900/80 p-4 shadow-2xl sm:p-6 xl:p-8',
+	layout:
+		'grid w-full min-w-0 grid-cols-1 items-start justify-items-center gap-6 text-center xl:grid-cols-[1fr_auto_1fr]',
+	playArea:
+		'flex w-full min-w-0 max-w-96 flex-col items-center xl:col-start-2',
+	boardGrid:
+		'grid w-full max-w-96 grid-cols-3 gap-3 rounded-2xl border border-white/10 bg-black/20 p-4 sm:p-8',
+	spectatorArea: 'mt-6 text-white/60 font-medium',
+	popupArea: 'w-full min-w-0 max-w-80 xl:col-start-3 xl:justify-self-start',
+} as const;
+
+export const endGamePopupClasses = {
+	card:
+		'flex min-w-80 max-w-[90vw] flex-col items-center gap-4 bg-slate-900 p-8 text-white hover:scale-100',
+	title:
+		'flex max-w-full items-center justify-center gap-2 text-center text-2xl font-bold',
+	winnerName: 'max-w-32 font-bold',
+	subtitle: 'text-center text-sm font-medium text-white/70',
+	replayActions: 'flex flex-col items-center gap-3',
+	replayVotes: 'flex gap-2 text-xs font-bold',
+	vote: 'rounded-full border px-3 py-1',
+	voteXActive: 'border-cyan-400 text-cyan-400',
+	voteOActive: 'border-fuchsia-400 text-fuchsia-400',
+	voteInactive: 'border-white/10 text-white/40',
+	disabledReplayText: 'text-center text-sm text-white/50',
+} as const;
+
+export const gameStatusBannerClasses = {
+	error:
+		'mb-4 rounded-lg border border-red-400 bg-red-500/20 px-4 py-3 text-red-200',
+	disconnect:
+		'border border-orange-400 bg-orange-500/20 px-4 py-3 text-orange-100',
+} as const;
+
+export const playerCardsClasses = {
+	symbolBadge:
+		'grid h-5 w-5 shrink-0 place-items-center rounded-full border border-white/10 bg-white/5 sm:h-6 sm:w-6',
+	symbolIcon: 'h-3.5 w-3.5 stroke-3 sm:h-4 sm:w-4',
+	youLabel:
+		'absolute inset-x-0 -top-4 text-center text-[10px] font-bold uppercase text-cyan-400 sm:-top-6 sm:text-xs',
+	card: 'flex w-24 flex-col items-center p-2 sm:w-28 sm:p-3',
+	activeCard: 'ring-2 ring-cyan-400',
+	nameRow:
+		'mt-2 flex w-full min-w-0 items-center justify-center gap-1 font-bold sm:mt-3',
+	name: 'max-w-10 text-[11px] font-bold sm:max-w-14 sm:text-xs',
+	container:
+		'mb-3 flex w-full max-w-[280px] items-center justify-between text-white sm:mb-8 sm:max-w-96',
+	timer:
+		'grid size-11 place-items-center rounded-full text-xs font-bold sm:size-16 sm:text-sm',
+} as const;
+
+export const spectatorCountClasses = {
+	container:
+		'mb-2 flex items-center justify-center gap-1 text-xs text-white/60',
+} as const;
+
+export const squareClasses = {
+	button:
+		'aspect-square w-full rounded-xl border border-white/40 bg-white/10 text-7xl font-bold shadow-md active:scale-95 hover:bg-white/20 transition-all flex items-center justify-center',
+	value: 'transition-all duration-300',
+	xValue: 'text-cyan-400',
+	oValue: 'text-fuchsia-400',
+	warning: 'opacity-30 scale-75',
+	normal: 'opacity-100',
+} as const;

--- a/frontend/src/type/user.types.ts
+++ b/frontend/src/type/user.types.ts
@@ -17,8 +17,11 @@ export type UserChat = {
   avatar: string | null;
 };
 
+/**
+ * Message payload received from the chat socket.
+ */
 export type ChatMessage = {
-  id: number;
+  id: string;
   content: string;
   createdAt: string;
   user: UserChat;


### PR DESCRIPTION
## Summary

Refs #260
Close #287
Refs #148

This PR is mostly a cleanup for the game and chat parts.

The goal was to make the realtime code easier to read, add better types, clean some comments, and improve the game board responsive layout.

## What changed

- Cleaned some game backend files
- Added comments on important game functions
- Removed unused game code/types
- Added better socket payload types on the frontend
- Improved chat message validation
- Trim chat messages before sending them
- Changed chat message ids to UUID instead of timestamp
- Added max length on the chat input
- Extracted some game/chat Tailwind classes into one shared file
- Improved the game board layout on smaller screens
- Improved player cards, timer, replay popup, and spectator count layout
- Moved the redirect from render into a `useEffect`

## Why

The game and chat were already working, but some files were getting hard to read.

This PR does not try to add a big new feature.  
It is mainly here to make the code cleaner before the next fixes and reviews.

## Tests to do

- [x] Test game create/join/play
- [x] Test replay popup
- [x] Test leave/cancel game
- [x] Test chat normal message
- [x] Test empty chat message
- [x] Test too long chat message
- [x] Check mobile layout
- [x] Check browser console

## Notes

I used `Refs` and not `Closes` because this PR only improves parts of these issues.

No issue is fully finished by this PR.