### PR TITLE
[BUG] Fix opponent disconnect message and remove VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ cookies.txt
 
 # random images for avatar
 test-images/
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "i18n-ally.localesPaths": ["frontend/src/i18n"],
-  "i18n-ally.keystyle": "nested"
-}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -106,7 +106,7 @@
     "waitingOpponent": "Waiting for opponent...",
     "waitingMove": "Waiting for opponent move...",
     "status": {
-      "opponentDisconnected": "Opponent disconnected — waiting 20s for reconnection..",
+      "opponentDisconnected": "Opponent disconnected",
       "opponentLeft": "The opponent has left the game - no replay!",
       "opponentReconnected": "The opponent has reconnected!"
     },
@@ -143,7 +143,7 @@
     "replayVotes": "Replay votes",
     "waitingReplayOther": "Replay requested. Waiting for the other player...",
     "timer": "Time left: {{seconds}}s",
-    "opponentDisconnect": "Opponent disconnected — waiting 20s for reconnection..."
+    "opponentDisconnect": "Opponent disconnected"
   },
   "play": {
     "myGames": {

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -106,7 +106,7 @@
     "waitingOpponent": "Esperando al oponente...",
     "waitingMove": "Esperando que el oponente se mueva...",
     "status": {
-      "opponentDisconnected": "Oponente desconectado: esperando 20 segundos para volver a conectarse.",
+      "opponentDisconnected": "Oponente desconectado",
       "opponentLeft": "El oponente ha abandonado el juego: ¡no se puede repetir!",
       "opponentReconnected": "¡El oponente se ha vuelto a conectar!"
     },
@@ -143,7 +143,7 @@
     "replayVotes": "Reproducir votos",
     "waitingReplayOther": "Repetición solicitada. \nEsperando al otro jugador...",
     "timer": "Tiempo restante: {{seconds}}s",
-    "opponentDisconnect": "Oponente desconectado: esperando 20 segundos para volver a conectarse..."
+    "opponentDisconnect": "Oponente desconectado"
   },
   "play": {
     "myGames": {

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -106,7 +106,7 @@
     "waitingOpponent": "En attente de l'adversaire...",
     "waitingMove": "En attente du coup de l'adversaire...",
     "status": {
-      "opponentDisconnected": "Adversaire déconnecté – attente 20 secondes pour la reconnexion.",
+      "opponentDisconnected": "Adversaire déconnecté",
       "opponentLeft": "L'adversaire a quitté la partie - pas de replay !",
       "opponentReconnected": "L'adversaire s'est reconnecté !"
     },
@@ -143,7 +143,7 @@
     "replayVotes": "Rejouer les votes",
     "waitingReplayOther": "Replay demandé. \nEn attendant l'autre joueur...",
     "timer": "Temps restant : {{seconds}}s",
-    "opponentDisconnect": "Adversaire déconnecté — attente 20 secondes pour la reconnexion..."
+    "opponentDisconnect": "Adversaire déconnecté"
   },
   "play": {
     "myGames": {


### PR DESCRIPTION
## Summary

This PR fixes the game disconnect message requested by the team.

Instead of showing a confusing sentence, the message is now clearer:

- `Opponent disconnected`
- `Adversaire déconnecté`
- `Oponente desconectado`

It was updated in the 3 translation files for both related keys.

## Also

Removed `.vscode/settings.json` from Git and added `.vscode/` to `.gitignore` to avoid pushing personal VSCode settings.

Close #227 