### PR TITLE
[BUG] - Auto-login user on registration

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -35,30 +35,22 @@ export class AuthController {
 	) {}
 
 	@Public()
-	@ApiOperation({ summary: 'Register a new user' })
-	@ApiBody({ type: RegisterDto })
-	@ApiResponse({
-		status: 201,
-		description: 'User registered successfully',
-	})
-	@ApiResponse({
-		status: 400,
-		description: 'Invalid input data',
-	})
 	@Post('register')
+	@ApiOperation({ summary: 'Register a new user and start a session' })
+	@ApiBody({ type: RegisterDto })
+	@ApiCreatedResponse({ description: 'User registered successfully' })
+	@ApiBadRequestResponse({ description: 'Invalid input data' })
+	@ApiConflictResponse({ description: 'Email or username already exists' })
 	async register(
 		@Body() registerDto: RegisterDto,
 		@Res({ passthrough: true }) res: Response,
 	) {
 		const user = await this.authService.register(registerDto);
 		const accessToken = await this.authService.signTokenForUser(user);
-		res.cookie('access_token', accessToken, {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === 'production',
-			sameSite: 'lax',
-			maxAge: 8 * 60 * 60 * 1000,
-			path: '/',
-		});
+
+		res.cookie('access_token', accessToken, accessTokenCookieOptions);
+		res.clearCookie('2fa_pending', baseCookieOptions);
+
 		return user;
 	}
 

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -46,8 +46,20 @@ export class AuthController {
 		description: 'Invalid input data',
 	})
 	@Post('register')
-	register(@Body() registerDto: RegisterDto) {
-		return this.authService.register(registerDto);
+	async register(
+		@Body() registerDto: RegisterDto,
+		@Res({ passthrough: true }) res: Response,
+	) {
+		const user = await this.authService.register(registerDto);
+		const accessToken = await this.authService.signTokenForUser(user);
+		res.cookie('access_token', accessToken, {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === 'production',
+			sameSite: 'lax',
+			maxAge: 8 * 60 * 60 * 1000,
+			path: '/',
+		});
+		return user;
 	}
 
 	@Public()


### PR DESCRIPTION
## Checklist

- [x] Target branch is `dev`
- [x] No `.env` or sensitive files committed

## What was done

### **Backend:**

- Updated `register()` in `auth.controller.ts` to be `async` and accept `@Res({ passthrough: true })`
- After successful registration, calls `signTokenForUser()` and sets the JWT as an `access_token` cookie with the same options used by the login endpoint

## Why

After registering, the user was not logged in. The frontend received a success response but no JWT cookie was set, so the subsequent call to `/auth/me` returned 401 and the user was redirected back to the login page.

Fixing this in the controller keeps the change minimal. Registration and login now share the same cookie-setting path without duplicating business logic in the service.

## Testing

- [x] Docker build successful
- [x] Integration tested manually

## Production Tests

### Prod Test 1 — Registration sets cookie and auto-logs in user

**1. Start the stack:**

```bash
make prod
```

**2. Open browser DevTools (Network tab) before registering.**

**3. Register a new account via the UI.**

> **Note:** Confirm no 401 errors appear in the console and that you land on the home/dashboard page without being redirected back to login.

---
