### PR TITLE
[FRONT] Add pagination to Friends user search

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -251,7 +251,10 @@
     "search": {
       "title": "Find users",
       "placeholder": "Search by username",
-      "button": "Search"
+      "button": "Search",
+      "previous": "Previous",
+      "next": "Next",
+      "page": "Page {{page}}"
     },
     "list": {
       "title": "Friends list",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -251,7 +251,10 @@
     "search": {
       "title": "Buscar usuarios",
       "placeholder": "Buscar por nombre de usuario",
-      "button": "Buscar"
+      "button": "Buscar",
+      "previous": "Anterior",
+      "next": "Siguiente",
+      "page": "Página {{page}}"
     },
     "list": {
       "title": "Lista de amigos",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -251,7 +251,10 @@
     "search": {
       "title": "Rechercher des utilisateurs",
       "placeholder": "Rechercher par nom d'utilisateur",
-      "button": "Rechercher"
+      "button": "Rechercher",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "page": "Page {{page}}"
     },
     "list": {
       "title": "Liste d'amis",

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -363,11 +363,13 @@ export default function Friends() {
 							onClick={handlePreviousSearchPage}
 							disabled={!hasPreviousSearchPage || searchLoading}
 						>
-							Previous
+							{t("friends.search.previous")}
 						</Button>
 
 						<span className="text-sm text-white/50">
-							Page {currentSearchPage}
+							{t("friends.search.page", {
+								page: currentSearchPage,
+							})}
 						</span>
 
 						<Button
@@ -376,7 +378,7 @@ export default function Friends() {
 							onClick={handleNextSearchPage}
 							disabled={!hasNextSearchPage || searchLoading}
 						>
-							Next
+							{t("friends.search.next")}
 						</Button>
 					</div>
 				)}

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -77,7 +77,7 @@ export default function Friends() {
 
 	const currentSearchPage = Math.floor(searchOffset / SEARCH_PAGE_SIZE) + 1;
 	const hasPreviousSearchPage = searchOffset > 0;
-	const hasNextSearchPage = searchResults.length === SEARCH_PAGE_SIZE;
+	const [hasNextSearchPage, setHasNextSearchPage] = useState(false);
 
 	const incomingRequestBySenderId = useMemo(() => {
 		return new Map(
@@ -153,11 +153,12 @@ export default function Friends() {
 		try {
 			const results = await friendsService.searchUsers(
 				query,
-				SEARCH_PAGE_SIZE,
+				SEARCH_PAGE_SIZE + 1,
 				offset,
 			);
 
-			setSearchResults(results);
+			setSearchResults(results.slice(0, SEARCH_PAGE_SIZE));
+			setHasNextSearchPage(results.length > SEARCH_PAGE_SIZE);
 			setSearchOffset(offset);
 			setLastSearchQuery(query);
 		} catch (error: unknown) {
@@ -184,6 +185,7 @@ export default function Friends() {
 			setSearchResults([]);
 			setSearchOffset(0);
 			setLastSearchQuery("");
+			setHasNextSearchPage(false);
 			return;
 		}
 
@@ -321,7 +323,18 @@ export default function Friends() {
 				>
 					<Input
 						value={search}
-						onChange={(event) => setSearch(event.target.value)}
+						onChange={(event) => {
+							const value = event.target.value;
+
+							setSearch(value);
+
+							if (!value.trim()) {
+								setSearchResults([]);
+								setSearchOffset(0);
+								setLastSearchQuery("");
+								setHasNextSearchPage(false);
+							}
+						}}
 						placeholder={t("friends.search.placeholder")}
 					/>
 

--- a/frontend/src/pages/Friends.tsx
+++ b/frontend/src/pages/Friends.tsx
@@ -54,6 +54,8 @@ const defaultOfflineStatus = (userId: number): FriendStatus => ({
 	activity: "offline",
 });
 
+const SEARCH_PAGE_SIZE = 10;
+
 export default function Friends() {
 	const { t } = useTranslation();
 	const [user] = useOutletContext<[CurrentUser | null]>();
@@ -68,8 +70,14 @@ export default function Friends() {
 	const friendStatus = usePresenceStore((state) => state.friendStatus);
 
 	const [search, setSearch] = useState("");
+	const [lastSearchQuery, setLastSearchQuery] = useState("");
+	const [searchOffset, setSearchOffset] = useState(0);
 	const [searchResults, setSearchResults] = useState<PublicUser[]>([]);
 	const [searchLoading, setSearchLoading] = useState(false);
+
+	const currentSearchPage = Math.floor(searchOffset / SEARCH_PAGE_SIZE) + 1;
+	const hasPreviousSearchPage = searchOffset > 0;
+	const hasNextSearchPage = searchResults.length === SEARCH_PAGE_SIZE;
 
 	const incomingRequestBySenderId = useMemo(() => {
 		return new Map(
@@ -123,33 +131,94 @@ export default function Friends() {
 	}
 
 	/**
+	 * Loads one page of user search results.
+	 *
+	 * This helper centralizes paginated search loading so:
+	 * - initial searches
+	 * - next page requests
+	 * - previous page requests
+	 *
+	 * all reuse the same API logic and loading state handling.
+	 *
+	 * @param query - Username search query.
+	 * @param offset - Number of users skipped before loading results.
+	 * @returns Nothing. Updates local pagination and search result state.
+	 */
+	async function loadSearchResults(
+		query: string,
+		offset: number,
+	): Promise<void> {
+		setSearchLoading(true);
+
+		try {
+			const results = await friendsService.searchUsers(
+				query,
+				SEARCH_PAGE_SIZE,
+				offset,
+			);
+
+			setSearchResults(results);
+			setSearchOffset(offset);
+			setLastSearchQuery(query);
+		} catch (error: unknown) {
+			showActionError(error, "friends.errors.search");
+		} finally {
+			setSearchLoading(false);
+		}
+	}
+
+	/**
 	 * Searches users by username.
 	 *
 	 * @param event - Search form submit event.
 	 * @returns Nothing. Updates local search result state.
 	 */
-	async function handleSearch(event: React.FormEvent<HTMLFormElement>) {
+	async function handleSearch(
+		event: React.FormEvent<HTMLFormElement>,
+	): Promise<void> {
 		event.preventDefault();
 
 		const trimmedSearch = search.trim();
 
 		if (!trimmedSearch) {
 			setSearchResults([]);
+			setSearchOffset(0);
+			setLastSearchQuery("");
 			return;
 		}
 
-		try {
-			setSearchLoading(true);
-			setSearchResults([]);
+		await loadSearchResults(trimmedSearch, 0);
+	}
 
-			const results = await friendsService.searchUsers(trimmedSearch);
-
-			setSearchResults(results);
-		} catch (error: unknown) {
-			showActionError(error, "friends.errors.search");
-		} finally {
-			setSearchLoading(false);
+	/**
+	 * Loads the previous page of search results.
+	 *
+	 * @returns Nothing. Reuses the last submitted search query.
+	 */
+	async function handlePreviousSearchPage(): Promise<void> {
+		if (!lastSearchQuery || !hasPreviousSearchPage) {
+			return;
 		}
+
+		const previousOffset = Math.max(searchOffset - SEARCH_PAGE_SIZE, 0);
+
+		await loadSearchResults(lastSearchQuery, previousOffset);
+	}
+
+	/**
+	 * Loads the next page of search results.
+	 *
+	 * @returns Nothing. Reuses the last submitted search query.
+	 */
+	async function handleNextSearchPage(): Promise<void> {
+		if (!lastSearchQuery || !hasNextSearchPage) {
+			return;
+		}
+
+		await loadSearchResults(
+			lastSearchQuery,
+			searchOffset + SEARCH_PAGE_SIZE,
+		);
 	}
 
 	/**
@@ -286,6 +355,31 @@ export default function Friends() {
 						);
 					})}
 				</div>
+				{searchResults.length > 0 && (
+					<div className="flex items-center justify-between pt-4">
+						<Button
+							size="sm"
+							variant="secondary"
+							onClick={handlePreviousSearchPage}
+							disabled={!hasPreviousSearchPage || searchLoading}
+						>
+							Previous
+						</Button>
+
+						<span className="text-sm text-white/50">
+							Page {currentSearchPage}
+						</span>
+
+						<Button
+							size="sm"
+							variant="secondary"
+							onClick={handleNextSearchPage}
+							disabled={!hasNextSearchPage || searchLoading}
+						>
+							Next
+						</Button>
+					</div>
+				)}
 			</Card>
 
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/frontend/src/services/friendsService.ts
+++ b/frontend/src/services/friendsService.ts
@@ -101,16 +101,19 @@ async function getOutgoingFriendRequests(): Promise<OutgoingFriendRequest[]> {
  *
  * @param query - Username search text.
  * @param limit - Maximum number of users to return.
+ * @param offset - Number of users to skip before returning results.
  * @returns Matching public users.
  */
 async function searchUsers(
 	query: string,
 	limit = 10,
+	offset = 0,
 ): Promise<PublicUser[]> {
 	const response = await api.get<PublicUser[]>("users", {
 		params: {
 			search: query,
 			limit,
+			offset,
 		},
 	});
 


### PR DESCRIPTION
## Summary

This PR adds frontend pagination to the Friends page user search.

The goal is to help validate the subject module:

`Minor: Implement advanced search functionality with filters, sorting, and pagination.`

The existing backend search endpoint already supported:

* `search`
* `limit`
* `offset`

This PR integrates those query parameters into the frontend search flow while preserving the existing Friends system behavior and realtime logic.

---

# What was done

## Paginated Friends search

Updated the Friends search flow to support frontend pagination using the existing backend API query parameters.

The frontend now requests paginated results through:

```txt
GET /users?search=...&limit=...&offset=...
```

Pagination behavior:

* first page loads with offset `0`
* next page increments offset by `10`
* previous page decrements offset by `10`
* pagination resets when a new search is submitted

---

## Centralized paginated search loader

Added a reusable helper:

```ts
loadSearchResults(query, offset)
```

This centralizes:

* API requests
* pagination state updates
* loading state handling
* search result updates

This avoids duplicating search logic across:

* initial search submit
* next page navigation
* previous page navigation

---

## Pagination controls

Added frontend pagination controls to the Friends search UI:

* Previous
* Next
* Current page indicator

Behavior:

* Previous is disabled on the first page
* Next is disabled when no additional page exists
* search state remains stable while navigating pages

---

## Empty page prevention

Improved pagination edge-case handling.

The frontend now requests:

```txt
SEARCH_PAGE_SIZE + 1
```

results internally to detect whether another page exists.

Only the first 10 users are displayed.

This prevents the UI from showing a false "Next" button when the current page contains exactly 10 users but no additional page actually exists.

---

## Search cleanup improvements

Search state now clears automatically when the input becomes empty.

This prevents stale paginated results from remaining visible after clearing the search field.

---

## i18n support

Added translation support for pagination controls in:

* English
* French
* Spanish

New translation keys:

* `friends.search.previous`
* `friends.search.next`
* `friends.search.page`

---

# Security review

No authorization logic was moved to the frontend.

The frontend only controls:

* pagination UI state
* limit/offset navigation

The backend remains responsible for:

* authentication
* authorization
* query validation
* safe public user responses

No private user fields are exposed.

No `any` types were introduced.

---

# Files modified

```txt
frontend/src/pages/Friends.tsx
frontend/src/services/friendsService.ts
frontend/src/i18n/en.json
frontend/src/i18n/fr.json
frontend/src/i18n/es.json
```

---

# How to test

## Manual tests

0. Register a Dummy10
1. Login
2. Open the Friends page
3. Search a username prefix with more than 10 users
4. Confirm only 10 results appear
5. Click Next
6. Confirm the next page loads correctly
7. Click Previous
8. Confirm the previous page loads correctly
9. Search a different query
10. Confirm pagination resets to page 1
11. Clear the search input
12. Confirm results disappear immediately
13. Search a query returning exactly 10 users
14. Confirm no empty extra page appears
15. Switch application language
16. Confirm pagination translations update correctly
17. Send/accept/remove friend requests from paginated results
18. Confirm relationship states still work correctly

---

Closes #326 
