### PR TITLE
[FRONTEND] : Fix Endgame popup truncation + responsiveness

### DIFF
--- a/frontend/src/components/game/EndGamePopup.tsx
+++ b/frontend/src/components/game/EndGamePopup.tsx
@@ -54,11 +54,13 @@ export function EndGamePopup({
 			>
 				{endGameMessage.winnerName ? (
 					<>
-						<Username
-							name={endGameMessage.winnerName}
-							variant="card"
-							className={endGamePopupClasses.winnerName}
-						/>
+						<div className="min-w-0">
+							<Username
+								name={endGameMessage.winnerName}
+								variant="card"
+								className={endGamePopupClasses.winnerName}
+							/>	
+						</div>
 						<span>{endGameMessage.resultText}</span>
 					</>
 				) : (

--- a/frontend/src/styles/gameChatClasses.ts
+++ b/frontend/src/styles/gameChatClasses.ts
@@ -28,7 +28,7 @@ export const boardClasses = {
 
 export const endGamePopupClasses = {
 	card:
-		'flex min-w-80 max-w-[90vw] flex-col items-center gap-4 bg-slate-900 p-8 text-white hover:scale-100',
+		'flex max-w-[90vw] flex-col items-center gap-4 bg-slate-900 p-6 sm:p-8 text-white hover:scale-100',
 	title:
 		'flex max-w-full items-center justify-center gap-2 text-center text-2xl font-bold',
 	winnerName: 'max-w-32 font-bold',


### PR DESCRIPTION
## Summary

This PR improves the responsiveness of the Endgame popup by properly handling long usernames.

Usernames can now truncate correctly inside flexible containers thanks to the addition of `min-w-0`, preventing layout overflow issues on smaller screens.

## Main changes

- add `min-w-0` to username containers inside the Endgame popup
- remove fixed `min-w-80` constraint from the Endgame modal
- improve text truncation behavior for long usernames
- prevent overflow/layout breaking on mobile resolutions
- improve overall responsiveness of the Endgame modal UI

## Result

The Endgame popup now remains visually stable and responsive across different screen sizes, even with very long usernames.

## How to test

- Launch the application
- Test with very long usernames
- Start and finish a game to open the Endgame popup
- Verify that usernames truncate correctly without overflowing
- Resize the browser window and test mobile resolutions
- Confirm that the popup remains responsive and properly centered
- Ensure no horizontal overflow appears on small screens