### PR TITLE
[BACKEND] Fix Prisma seed error when deleting dummy games

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,9 +1,8 @@
-import { Pool } from "pg";
-import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from 'pg';
+import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import * as fs from 'node:fs';
-
 
 // ── Define Prisma Client ────────────────────────────────────────────────────
 const backendPw = fs.readFileSync('/run/secrets/backend_pw', 'utf8').trim();
@@ -12,122 +11,144 @@ const pool = new Pool({ connectionString });
 const adapter = new PrismaPg(pool);
 const prisma = new PrismaClient({ adapter });
 
-
 // ── Define Constants ────────────────────────────────────────────────────────
 const DUMMY_COUNT = 10;
 const PASSWORD = 'Dummy123';
-const DUMMY_USERNAMES = Array.from({ length: DUMMY_COUNT }, (_, n) => `dummy${n}`);
+const DUMMY_USERNAMES = Array.from(
+	{ length: DUMMY_COUNT },
+	(_, n) => `dummy${n}`,
+);
 const AVATARS = Array.from(
-  { length: DUMMY_COUNT },
-  (_, n) => `https://api.dicebear.com/9.x/pixel-art/svg?seed=dummy${n}`
+	{ length: DUMMY_COUNT },
+	(_, n) => `https://api.dicebear.com/9.x/pixel-art/svg?seed=dummy${n}`,
 );
 
 // ── Define Simulated Games Outcome ──────────────────────────────────────────
 const GAMES = [
-  { p1: 0, p2: 1, s1: 1, s2: 0, winner: 0,    endReason: 'win'     },
-  { p1: 2, p2: 3, s1: 0, s2: 1, winner: 3,    endReason: 'win'     },
-  { p1: 4, p2: 5, s1: 0, s2: 0, winner: null, endReason: 'draw'    },
-  { p1: 6, p2: 7, s1: 0, s2: 1, winner: 7,    endReason: 'win'     },
-  { p1: 8, p2: 9, s1: 1, s2: 0, winner: 8,    endReason: 'win'     },
-  { p1: 0, p2: 3, s1: 0, s2: 1, winner: 3,    endReason: 'win'     },
-  { p1: 1, p2: 4, s1: 1, s2: 0, winner: 1,    endReason: 'win'     },
-  { p1: 2, p2: 5, s1: 1, s2: 0, winner: 2,    endReason: 'forfeit' },
-  { p1: 6, p2: 9, s1: 0, s2: 1, winner: 9,    endReason: 'win'     },
-  { p1: 7, p2: 8, s1: 1, s2: 0, winner: 7,    endReason: 'win'     },
-  { p1: 0, p2: 5, s1: 0, s2: 1, winner: 5,    endReason: 'win'     },
-  { p1: 1, p2: 6, s1: 0, s2: 0, winner: null, endReason: 'draw'    },
-  { p1: 3, p2: 8, s1: 1, s2: 0, winner: 3,    endReason: 'win'     },
-  { p1: 4, p2: 9, s1: 0, s2: 1, winner: 9,    endReason: 'forfeit' },
-  { p1: 2, p2: 7, s1: 1, s2: 0, winner: 2,    endReason: 'win'     },
-  { p1: 0, p2: 9, s1: 1, s2: 0, winner: 0,    endReason: 'win'     },
-  { p1: 1, p2: 8, s1: 0, s2: 1, winner: 8,    endReason: 'win'     },
-  { p1: 5, p2: 6, s1: 1, s2: 0, winner: 5,    endReason: 'win'     },
-  { p1: 3, p2: 7, s1: 0, s2: 0, winner: null, endReason: 'draw'    },
-  { p1: 4, p2: 8, s1: 0, s2: 1, winner: 8,    endReason: 'win'     },
+	{ p1: 0, p2: 1, s1: 1, s2: 0, winner: 0, endReason: 'win' },
+	{ p1: 2, p2: 3, s1: 0, s2: 1, winner: 3, endReason: 'win' },
+	{ p1: 4, p2: 5, s1: 0, s2: 0, winner: null, endReason: 'draw' },
+	{ p1: 6, p2: 7, s1: 0, s2: 1, winner: 7, endReason: 'win' },
+	{ p1: 8, p2: 9, s1: 1, s2: 0, winner: 8, endReason: 'win' },
+	{ p1: 0, p2: 3, s1: 0, s2: 1, winner: 3, endReason: 'win' },
+	{ p1: 1, p2: 4, s1: 1, s2: 0, winner: 1, endReason: 'win' },
+	{ p1: 2, p2: 5, s1: 1, s2: 0, winner: 2, endReason: 'forfeit' },
+	{ p1: 6, p2: 9, s1: 0, s2: 1, winner: 9, endReason: 'win' },
+	{ p1: 7, p2: 8, s1: 1, s2: 0, winner: 7, endReason: 'win' },
+	{ p1: 0, p2: 5, s1: 0, s2: 1, winner: 5, endReason: 'win' },
+	{ p1: 1, p2: 6, s1: 0, s2: 0, winner: null, endReason: 'draw' },
+	{ p1: 3, p2: 8, s1: 1, s2: 0, winner: 3, endReason: 'win' },
+	{ p1: 4, p2: 9, s1: 0, s2: 1, winner: 9, endReason: 'forfeit' },
+	{ p1: 2, p2: 7, s1: 1, s2: 0, winner: 2, endReason: 'win' },
+	{ p1: 0, p2: 9, s1: 1, s2: 0, winner: 0, endReason: 'win' },
+	{ p1: 1, p2: 8, s1: 0, s2: 1, winner: 8, endReason: 'win' },
+	{ p1: 5, p2: 6, s1: 1, s2: 0, winner: 5, endReason: 'win' },
+	{ p1: 3, p2: 7, s1: 0, s2: 0, winner: null, endReason: 'draw' },
+	{ p1: 4, p2: 8, s1: 0, s2: 1, winner: 8, endReason: 'win' },
 ];
 
 // ── Seed Database ───────────────────────────────────────────────────────────
 async function main() {
+	// ── Update or Create Users ───────────────────────────────────────────
+	console.log(`\x1b[36m>>> Seeding Dummy Users`);
 
-  // ── Update or Create Users ───────────────────────────────────────────
-  console.log(`\x1b[36m>>> Seeding Dummy Users`)
+	const passwordHash = await bcrypt.hash(PASSWORD, 10);
 
-  const passwordHash = await bcrypt.hash(PASSWORD, 10);
+	const users: Array<{ id: number }> = [];
 
-  for (let n = 0; n < DUMMY_COUNT; n++) {
-    await prisma.user.upsert({
-      where: { email: `dummy${n}@mail.com` },
-      update: {},
-      create: {
-        email: `dummy${n}@mail.com`,
-        username: `dummy${n}`,
-        passwordHash,
-        avatar: AVATARS[n],
-      },
-    });
-  process.stdout.write(`\r\x1b[32m✓ Seeded dummy ${n + 1}/${DUMMY_COUNT}\x1b[0m`);
+	for (let n = 0; n < DUMMY_COUNT; n++) {
+		const username = DUMMY_USERNAMES[n];
+		const user = await prisma.user.upsert({
+			where: { email: `${username}@mail.com` },
+			update: {},
+			create: {
+				email: `${username}@mail.com`,
+				username,
+				passwordHash,
+				avatar: AVATARS[n],
+			},
+		});
+
+		users.push(user);
+		process.stdout.write(
+			`\r\x1b[32m✓ Seeded dummy ${n + 1}/${DUMMY_COUNT}\x1b[0m`,
+		);
+	}
+	console.log(``);
+
+	const dummyUserIds = users.map((user) => user.id);
+
+	// ── Wipe any existing games between dummy accounts ──────────────
+	await prisma.move.deleteMany({
+		where: {
+			game: {
+				is: {
+					player1Id: { in: dummyUserIds },
+					player2Id: { in: dummyUserIds },
+				},
+			},
+		},
+	});
+
+	await prisma.game.deleteMany({
+		where: {
+			player1Id: { in: dummyUserIds },
+			player2Id: { in: dummyUserIds },
+		},
+	});
+	console.log(
+		'\x1b[32m✓ Deleted any existing games and moves between dummy accounts',
+	);
+
+	// ── Add Games to Database ───────────────────────────────────────
+	for (const { p1, p2, winner, endReason, s1, s2 } of GAMES) {
+		await prisma.game.create({
+			data: {
+				player1Id: users[p1].id,
+				player2Id: users[p2].id,
+				winnerId: winner !== null ? users[winner].id : null,
+				endReason: endReason,
+				scoresP1: s1,
+				scoresP2: s2,
+			},
+		});
+	}
+	console.log('\x1b[32m✓ Added Games to Database');
+
+	// ── Calculate Stats and XP for users ────────────────────────────
+	for (const user of users) {
+		// ── Get Total Games ───────────────────────
+		const wins = await prisma.game.count({ where: { winnerId: user.id } });
+		const draws = await prisma.game.count({
+			where: {
+				OR: [{ player1Id: user.id }, { player2Id: user.id }],
+				endReason: 'draw',
+			},
+		});
+		const total = await prisma.game.count({
+			where: { OR: [{ player1Id: user.id }, { player2Id: user.id }] },
+		});
+		const losses = total - wins - draws;
+
+		// ── XP & Update User ──────────────────────
+		const xp = wins * 100 + draws * 50 + losses * 25;
+		await prisma.user.update({
+			where: { id: user.id },
+			data: { wins, losses, draws, xp, totalGames: total },
+		});
+	}
+	console.log("\x1b[32m✓ Updated Users' XP and Stats\x1b[0m");
 }
-  console.log(``);
-
-  // ── Fetch all users in ascending order ──────────────────────────
-  const users = await prisma.user.findMany({
-    where: { username: { in: DUMMY_USERNAMES } },
-    orderBy: { username: 'asc' },
-  });
-
-  // ── Wipe any existing games between dummy accounts ──────────────
-  await prisma.game.deleteMany({
-    where: {
-      player1: { username: { in: DUMMY_USERNAMES } },
-      player2: { username: { in: DUMMY_USERNAMES } },
-    },
-  });
-  console.log('\x1b[32m✓ Deleted any existing games between dummy accounts');
-
-  // ── Add Games to Database ───────────────────────────────────────
-  for (const {p1, p2, winner, endReason, s1, s2} of GAMES) {
-    await prisma.game.create({
-      data: {
-        player1Id: users[p1].id,
-        player2Id: users[p2].id,
-        winnerId: winner !== null ? users[winner].id : null,
-        endReason: endReason,
-        scoresP1: s1,
-        scoresP2: s2,
-      },
-    });
-  }
-  console.log('\x1b[32m✓ Added Games to Database')
-
-  // ── Calculate Stats and XP for users ────────────────────────────
-  for (const user of users) {
-    // ── Get Total Games ───────────────────────
-    const wins = await prisma.game.count({ where: { winnerId: user.id } });
-    const draws = await prisma.game.count({
-      where: { OR: [{ player1Id: user.id }, { player2Id: user.id }], endReason: 'draw' },
-    });
-    const total = await prisma.game.count({
-      where: { OR: [{ player1Id: user.id }, { player2Id: user.id }] },
-    });
-    const losses = total - wins - draws;
-
-    // ── XP & Update User ──────────────────────
-    const xp = wins * 100 + draws * 50 + losses * 25;
-    await prisma.user.update({ where: { id: user.id }, data: { wins, losses, draws, xp, totalGames: total } });
-  }
-  console.log('\x1b[32m✓ Updated Users\' XP and Stats\x1b[0m');
-}
-
 
 main()
-  .then(() => {
-    console.log("\x1b[36m>>> Seeding successful!\x1b[0m");
-  })
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-    await pool.end();
-  });
+	.then(() => {
+		console.log('\x1b[36m>>> Seeding successful!\x1b[0m');
+	})
+	.catch((e) => {
+		console.error(e);
+		process.exit(1);
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+		await pool.end();
+	});


### PR DESCRIPTION

## Summary

This PR fixes a Prisma/PostgreSQL seed error that happened when starting the backend in prod.

The app was still starting after the error, but the seed was not clean and it could look bad during evaluation.

## Problem

The seed was trying to delete existing `Game` rows between dummy users.

But some games already had related `Move` rows in the database.

Because of the foreign key between `Move` and `Game`, PostgreSQL blocked the delete with this error:

```txt
update or delete on table "Game" violates RESTRICT setting of foreign key constraint "Move_gameId_fkey" on table "Move"
````

## What we changed

We fixed the seed deletion order.

Before deleting dummy games, the seed now deletes the related moves first:

```ts
await prisma.move.deleteMany(...);
await prisma.game.deleteMany(...);
```

We also use the IDs returned by `upsert` for dummy users instead of relying only on usernames.

This makes the seed safer if a dummy user was renamed manually.

## Why this solution

We chose the safer fix for now.

Instead of changing `schema.prisma` and adding cascade delete globally, we only fixed the seed logic.

This avoids changing the global behavior of game deletion in the app just before evaluation.

## Main changes

* delete related `Move` rows before deleting dummy `Game` rows
* keep the Prisma schema unchanged
* use dummy user IDs returned by `upsert`
* make the seed cleaner and more stable
* remove the Prisma foreign key error from prod logs

## Result

The backend prod startup is now clean:

* seed runs successfully
* dummy users are created/updated
* old dummy games and moves are deleted correctly
* new dummy games are added
* user stats and XP are updated
* backend starts normally after the seed

## How to test

* Run `make prod`
* Check backend logs with:

```bash
make p-logs-back
```

* Confirm the logs show:

```txt
>>> Seeding successful!
Nest application successfully started
```

* Confirm there is no more:

```txt
DriverAdapterError
violates RESTRICT
Move_gameId_fkey
```

* Login with a dummy account, for example:

```txt
dummy0@mail.com
Dummy123
```

* Check that history / leaderboard still work
* Restart prod a second time to confirm the seed stays clean on repeated starts

## Notes

This PR only fixes the seed behavior.

It does not add `onDelete: Cascade` on the Prisma relation, so normal game deletion behavior in the app is not changed. This should help keep prod logs clean for evaluation without touching the global Prisma relation behavior.

