### PR TITLE
[FIX]: cleanup waiting game when creator disconnects

### DIFF
--- a/backend/src/modules/game/game.service.ts
+++ b/backend/src/modules/game/game.service.ts
@@ -335,6 +335,17 @@ export class GameService {
 		return this.activeGame.delete(gameId);
 	}
 
+	deleteWaitingGameByOwner(userId: number): void {
+		const active = this.findActiveGameByUserId(userId);
+		if (!active) return;
+
+		const [gameId, game] = active;
+		if (game.status === 'waiting' && game.players.X.ownerUserId === userId) {
+			this.activeGame.delete(gameId);
+			this.presenceService.emitActiveGameUpdated(userId, null);
+		}
+	}
+
 	/**
 	 * Persists a completed game to the database.
 	 * Maps the in-memory game state (X/O players) to the MatchesService format

--- a/backend/src/presence/presence.service.ts
+++ b/backend/src/presence/presence.service.ts
@@ -133,6 +133,7 @@ export class PresenceService {
 
 		if (sockets.size === 0) {
 			this.onlineUsers.delete(userId);
+			this.gameService.deleteWaitingGameByOwner(userId);
 
 			return {
 				userId,


### PR DESCRIPTION
## Summary

Fix waiting games staying active after the creator disconnects.

## Changes

- Added cleanup for waiting games owned by a disconnected user.
- When a user has no more presence sockets, we delete their waiting game if:
  - the game is still `waiting`
  - the user is the creator/player X

## Why

A waiting game should not stay visible if the creator fully left the app.

## Behavior

- Another tab still open → game is kept.
- Game already `playing` → game is kept.
- Only the waiting game owner can trigger this cleanup.

## Tradeoff

Simple fix: if the creator refreshes and presence drops to zero briefly, the waiting game can be deleted.  
A delayed cleanup would avoid that, but adds more complexity.

## Test

- Create a game, close/logout creator → waiting game disappears.
- Create a game, keep another tab open → game stays.
- Start a game, disconnect a player → playing game stays.